### PR TITLE
feat: 회원가입 API를 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
+++ b/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
@@ -1,0 +1,76 @@
+package sleepy.mollu.server.common.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sleepy.mollu.server.common.dto.ExceptionResponse;
+import sleepy.mollu.server.common.exception.*;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    private static final String BAD_REQUEST_ERROR_MESSAGE = "잘못된 요청입니다.";
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(BadRequestException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ExceptionResponse> handleBindingExceptions(BindException exception) {
+        final String message = exception.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(error -> String.format("%s: %s", ((FieldError) error).getField(), error.getDefaultMessage()))
+                .collect(Collectors.joining(", "));
+
+        logger.warn(message);
+
+        return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthenticationException(AuthenticationException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ExceptionResponse("인증에 실패했습니다."));
+    }
+
+    @ExceptionHandler(AuthorizationException.class)
+    public ResponseEntity<ExceptionResponse> handleAuthorizationException(AuthorizationException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ExceptionResponse("권한이 없습니다."));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionResponse("요청한 리소스를 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(ServerException.class)
+    public ResponseEntity<ExceptionResponse> handleServerException(ServerException exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ExceptionResponse("처리할 수 없는 예외입니다."));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ExceptionResponse("처리할 수 없는 예외입니다."));
+    }
+}

--- a/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
+++ b/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package sleepy.mollu.server.common.handler;
 
+import jakarta.servlet.ServletException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -60,6 +61,12 @@ public class ControllerAdvice {
     public ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException exception) {
         logger.warn(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionResponse("요청한 리소스를 찾을 수 없습니다."));
+    }
+
+    @ExceptionHandler(ServletException.class)
+    public ResponseEntity<ExceptionResponse> handleServletException(Exception exception) {
+        logger.warn(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(ServerException.class)

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -3,7 +3,6 @@ package sleepy.mollu.server.member.domain;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.validation.constraints.Email;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,9 +20,6 @@ public class Member {
     @Embedded
     private Name name;
 
-    @Email
-    private String email;
-
     @Embedded
     private MolluId molluId;
 
@@ -31,10 +27,9 @@ public class Member {
     private Birthday birthday;
 
     @Builder
-    public Member(String id, String name, String email, String molluId, LocalDate birthday) {
+    public Member(String id, String name, String molluId, LocalDate birthday) {
         this.id = id;
         this.name = new Name(name);
-        this.email = email;
         this.molluId = new MolluId(molluId);
         this.birthday = new Birthday(birthday);
     }

--- a/src/main/java/sleepy/mollu/server/member/dto/MemberBadRequestException.java
+++ b/src/main/java/sleepy/mollu/server/member/dto/MemberBadRequestException.java
@@ -1,0 +1,10 @@
+package sleepy.mollu.server.member.dto;
+
+import sleepy.mollu.server.common.exception.BadRequestException;
+
+public class MemberBadRequestException extends BadRequestException {
+
+    public MemberBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sleepy/mollu/server/member/dto/SignupRequest.java
+++ b/src/main/java/sleepy/mollu/server/member/dto/SignupRequest.java
@@ -1,0 +1,8 @@
+package sleepy.mollu.server.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record SignupRequest(@NotNull String name, @NotNull LocalDate birthday, @NotNull String molluId) {
+}

--- a/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
@@ -1,12 +1,16 @@
 package sleepy.mollu.server.oauth2.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.oauth2.domain.SocialToken;
-import sleepy.mollu.server.oauth2.dto.SocialLoginResponse;
+import sleepy.mollu.server.oauth2.dto.TokenResponse;
 import sleepy.mollu.server.oauth2.service.OAuth2Service;
 
 import java.io.IOException;
@@ -20,9 +24,19 @@ public class OAuth2Controller {
     private final OAuth2Service oauth2Service;
 
     @RequestMapping("/login")
-    public ResponseEntity<SocialLoginResponse> login(
+    public ResponseEntity<TokenResponse> login(
             @RequestParam("type") String type,
             @SocialToken String socialToken) throws GeneralSecurityException, IOException {
+
         return ResponseEntity.ok(oauth2Service.login(type, socialToken));
+    }
+
+    @RequestMapping("/signup")
+    public ResponseEntity<TokenResponse> signup(
+            @RequestParam("type") String type,
+            @SocialToken String socialToken,
+            @RequestBody @Valid SignupRequest request) throws GeneralSecurityException, IOException {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(oauth2Service.signup(type, socialToken, request));
     }
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/dto/SocialLoginResponse.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/dto/SocialLoginResponse.java
@@ -1,4 +1,0 @@
-package sleepy.mollu.server.oauth2.dto;
-
-public record SocialLoginResponse(String accessToken, String refreshToken) {
-}

--- a/src/main/java/sleepy/mollu/server/oauth2/dto/TokenResponse.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package sleepy.mollu.server.oauth2.dto;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2Service.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2Service.java
@@ -1,11 +1,13 @@
 package sleepy.mollu.server.oauth2.service;
 
-import sleepy.mollu.server.oauth2.dto.SocialLoginResponse;
+import sleepy.mollu.server.member.dto.SignupRequest;
+import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public interface OAuth2Service {
 
-    SocialLoginResponse login(String type, String socialToken) throws GeneralSecurityException, IOException;
+    TokenResponse login(String type, String socialToken) throws GeneralSecurityException, IOException;
+    TokenResponse signup(String type, String socialToken, SignupRequest request) throws GeneralSecurityException, IOException;
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
@@ -5,12 +5,16 @@ import lombok.RequiredArgsConstructor;
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
 import org.springframework.stereotype.Service;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.dto.MemberBadRequestException;
+import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.repository.MemberRepository;
-import sleepy.mollu.server.oauth2.dto.SocialLoginResponse;
+import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Set;
 
@@ -26,17 +30,54 @@ public class OAuth2ServiceImpl implements OAuth2Service {
     private final JwtGenerator jwtGenerator;
 
     @Override
-    public SocialLoginResponse login(String type, String socialToken) throws GeneralSecurityException, IOException {
+    public TokenResponse login(String type, String socialToken) throws GeneralSecurityException, IOException {
 
-        final OAuth2Client oAuth2Client = oAuth2ClientMap.get(type + BEAN_NAME_FORMAT);
-        final String memberId = oAuth2Client.getMemberId(socialToken);
-
-        if (!memberRepository.existsById(memberId)) {
-            throw new MemberNotFoundException("ID가 [" + memberId + "]인 멤버를 찾을 수 없습니다.");
-        }
+        final String memberId = getOAuth2MemberId(type, socialToken);
+        validateMemberNotExists(memberId);
 
         final JwtToken jwtToken = jwtGenerator.generate(memberId, Set.of("member"));
 
-        return new SocialLoginResponse(jwtToken.accessToken(), jwtToken.refreshToken());
+        return new TokenResponse(jwtToken.accessToken(), jwtToken.refreshToken());
+    }
+
+    private void validateMemberNotExists(String memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberNotFoundException("ID가 [" + memberId + "]인 멤버를 찾을 수 없습니다.");
+        }
+    }
+
+    private String getOAuth2MemberId(String type, String socialToken) throws GeneralSecurityException, IOException {
+
+        final OAuth2Client oAuth2Client = oAuth2ClientMap.get(type + BEAN_NAME_FORMAT);
+
+        return oAuth2Client.getMemberId(socialToken);
+    }
+
+    @Override
+    public TokenResponse signup(String type, String socialToken, SignupRequest request) throws GeneralSecurityException, IOException {
+
+        final String memberId = getOAuth2MemberId(type, socialToken);
+        validateMemberExists(memberId);
+        saveMember(memberId, request.name(), request.birthday(), request.molluId());
+
+        final JwtToken jwtToken = jwtGenerator.generate(memberId, Set.of("member"));
+
+        return new TokenResponse(jwtToken.accessToken(), jwtToken.refreshToken());
+    }
+
+    private void validateMemberExists(String memberId) {
+        if (memberRepository.existsById(memberId)) {
+            throw new MemberBadRequestException("ID가 [" + memberId + "]인 멤버가 이미 존재합니다.");
+        }
+    }
+
+    private void saveMember(String memberId, String name, LocalDate birthday, String molluId) {
+
+        memberRepository.save(Member.builder()
+                .id(memberId)
+                .name(name)
+                .birthday(birthday)
+                .molluId(molluId)
+                .build());
     }
 }

--- a/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
@@ -1,6 +1,8 @@
 package sleepy.mollu.server.oauth2.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -10,9 +12,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.oauth2.service.OAuth2Service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.time.LocalDate;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,37 +27,75 @@ class OAuth2ControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private OAuth2Service oauth2Service;
 
-    @Test
-    @DisplayName("소셜 로그인 API를 호출할 때 파라미터를 설정하지 않으 400을 반환한다")
-    void OAuth2ControllerTest() throws Exception {
-        // given & when
-        final ResultActions resultActions = mockMvc.perform(get("/auth/login"));
+    @Nested
+    @DisplayName("[소셜 로그인 API 호출 시] ")
+    class socialLoginTest {
 
-        // then
-        resultActions.andExpect(status().isBadRequest())
-                .andDo(print());
+        @Test
+        @DisplayName("파라미터를 설정하지 않으면 400을 반환한다")
+        void OAuth2ControllerTest() throws Exception {
+            // given & when
+            final ResultActions resultActions = mockMvc.perform(get("/auth/login"));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("호출에 성공하면 200을 반환한다")
+        void OAuth2ControllerTest2() throws Exception {
+            // given
+            final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("type", "google");
+
+            final HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + "test_token");
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(get("/auth/login")
+                    .params(params)
+                    .headers(headers));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                    .andDo(print());
+        }
     }
 
-    @Test
-    @DisplayName("소셜 로그인 API를 호출에 성공하면 200을 반환한다")
-    void OAuth2ControllerTest2() throws Exception {
-        // given
-        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("type", "google");
+    @Nested
+    @DisplayName("[소셜 회원가입 API 호출 시] ")
+    class socialSignupTest {
 
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + "test_token");
+        @Test
+        @DisplayName("호출에 성공하면 201을 반환한다")
+        void socialSignupTest1() throws Exception {
+            // given
+            final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("type", "google");
 
-        // when
-        final ResultActions resultActions = mockMvc.perform(get("/auth/login")
-                .params(params)
-                .headers(headers));
+            final HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + "test_token");
 
-        // then
-        resultActions.andExpect(status().isOk())
-                .andDo(print());
+            final SignupRequest request = new SignupRequest("김준형", LocalDate.now(), "molluId");
+            final String requestBody = objectMapper.writeValueAsString(request);
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(get("/auth/signup")
+                    .params(params)
+                    .headers(headers)
+                    .contentType("application/json")
+                    .content(requestBody));
+
+            // then
+            resultActions.andExpect(status().isCreated())
+                    .andDo(print());
+        }
     }
 }

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImplTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImplTest.java
@@ -9,21 +9,26 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.dto.MemberBadRequestException;
+import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.repository.MemberRepository;
 import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.LocalDate;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class OAuth2ServiceImplTest {
@@ -46,7 +51,7 @@ class OAuth2ServiceImplTest {
 
     @Nested
     @DisplayName("[소셜 로그인 서비스 호출시]")
-    class socialLoginTest {
+    class SocialLoginTest {
 
         private final String memberId = "memberId";
         private final String type = "type";
@@ -60,7 +65,7 @@ class OAuth2ServiceImplTest {
             given(oAuth2ClientMap.get(anyString())).willReturn(oAuth2Client);
 
             given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
-            given(memberRepository.existsById(anyString())).willReturn(false);
+            given(memberRepository.existsById(memberId)).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> oAuth2Service.login(type, socialToken))
@@ -78,7 +83,7 @@ class OAuth2ServiceImplTest {
             final String refreshToken = "refreshToken";
 
             given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
-            given(memberRepository.existsById(anyString())).willReturn(true);
+            given(memberRepository.existsById(memberId)).willReturn(true);
             given(jwtGenerator.generate(anyString(), anySet())).willReturn(JwtToken.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
@@ -89,6 +94,60 @@ class OAuth2ServiceImplTest {
 
             // then
             assertAll(
+                    () -> assertThat(tokenResponse.accessToken()).isEqualTo(accessToken),
+                    () -> assertThat(tokenResponse.refreshToken()).isEqualTo(refreshToken)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("[소셜 회원가입 서비스 호출시]")
+    class SocialSignupTest {
+
+        final String type = "type";
+        final String socialToken = "socialToken";
+        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId");
+        final String memberId = "memberId";
+
+
+        @Test
+        @DisplayName("회원가입을 했으면 예외를 던진다")
+        void SocialSignupTest1() throws GeneralSecurityException, IOException {
+            // given
+            OAuth2Client oAuth2Client = mock(OAuth2Client.class);
+            given(oAuth2ClientMap.get(anyString())).willReturn(oAuth2Client);
+
+            given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
+            given(memberRepository.existsById(memberId)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> oAuth2Service.signup(type, socialToken, request))
+                    .isInstanceOf(MemberBadRequestException.class);
+        }
+
+        @Test
+        @DisplayName("회원가입을 하지 않았으면 회원가입 이후 토큰을 발급한다")
+        void SocialSignupTest2() throws GeneralSecurityException, IOException {
+            // given
+            OAuth2Client oAuth2Client = mock(OAuth2Client.class);
+            given(oAuth2ClientMap.get(anyString())).willReturn(oAuth2Client);
+
+            final String accessToken = "accessToken";
+            final String refreshToken = "refreshToken";
+
+            given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
+            given(memberRepository.existsById(memberId)).willReturn(false);
+            given(jwtGenerator.generate(anyString(), anySet())).willReturn(JwtToken.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build());
+
+            // when
+            final TokenResponse tokenResponse = oAuth2Service.signup(type, socialToken, request);
+
+            // then
+            assertAll(
+                    () -> then(memberRepository).should(times(1)).save(any(Member.class)),
                     () -> assertThat(tokenResponse.accessToken()).isEqualTo(accessToken),
                     () -> assertThat(tokenResponse.refreshToken()).isEqualTo(refreshToken)
             );

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImplTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImplTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.repository.MemberRepository;
-import sleepy.mollu.server.oauth2.dto.SocialLoginResponse;
+import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -85,12 +85,12 @@ class OAuth2ServiceImplTest {
                     .build());
 
             // when
-            final SocialLoginResponse socialLoginResponse = oAuth2Service.login(type, socialToken);
+            final TokenResponse tokenResponse = oAuth2Service.login(type, socialToken);
 
             // then
             assertAll(
-                    () -> assertThat(socialLoginResponse.accessToken()).isEqualTo(accessToken),
-                    () -> assertThat(socialLoginResponse.refreshToken()).isEqualTo(refreshToken)
+                    () -> assertThat(tokenResponse.accessToken()).isEqualTo(accessToken),
+                    () -> assertThat(tokenResponse.refreshToken()).isEqualTo(refreshToken)
             );
         }
     }


### PR DESCRIPTION
## 상세 내용
- 로그인과 회원가입의 요청 파라미터, 응답 바디가 유사하여 OAuth2Controller와 OAuth2Service에 회원가입 컨트롤러, 서비스를 구현하였습니다.
- ControllerAdvice를 구현하여 예외 처리를 한 곳에서 처리하도록 하였습니다.

ObjectMapper를 통해 mockMvc의 requestBody를 설정하는 법을 학습하였습니다.

Close #16 
