### PR TITLE
fix: 컨텐츠의 created_at 컬럼이 null로 저장되는 오류를 해결한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/ServerApplication.java
+++ b/src/main/java/sleepy/mollu/server/ServerApplication.java
@@ -2,10 +2,9 @@ package sleepy.mollu.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
+//@EnableJpaAuditing
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sleepy/mollu/server/ServerApplication.java
+++ b/src/main/java/sleepy/mollu/server/ServerApplication.java
@@ -2,8 +2,10 @@ package sleepy.mollu.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sleepy/mollu/server/common/config/JpaAuditingConfig.java
+++ b/src/main/java/sleepy/mollu/server/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package sleepy.mollu.server.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/sleepy/mollu/server/common/domain/BaseEntityTest.java
+++ b/src/test/java/sleepy/mollu/server/common/domain/BaseEntityTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import sleepy.mollu.server.common.config.JpaAuditingConfig;
 import sleepy.mollu.server.content.domain.content.Content;
 import sleepy.mollu.server.content.repository.ContentRepository;
 
@@ -11,13 +14,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
+@Import(JpaAuditingConfig.class)
 class BaseEntityTest {
 
     @Autowired
     ContentRepository contentRepository;
 
     @Test
-    @DisplayName("BaseEntity를 상속받은 클래스는 create_at, updated_at 필드를 가진다.")
+    @DisplayName("BaseEntity 를 상속받은 클래스는 create_at, updated_at 필드가 null 이 아니다.")
     void BaseEntityTest() {
 
         // given

--- a/src/test/java/sleepy/mollu/server/common/domain/BaseEntityTest.java
+++ b/src/test/java/sleepy/mollu/server/common/domain/BaseEntityTest.java
@@ -1,0 +1,39 @@
+package sleepy.mollu.server.common.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sleepy.mollu.server.content.domain.content.Content;
+import sleepy.mollu.server.content.repository.ContentRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DataJpaTest
+class BaseEntityTest {
+
+    @Autowired
+    ContentRepository contentRepository;
+
+    @Test
+    @DisplayName("BaseEntity를 상속받은 클래스는 create_at, updated_at 필드를 가진다.")
+    void BaseEntityTest() {
+
+        // given
+        final String id = "ID";
+        final String contentTag = "TAG";
+
+        final Content content = contentRepository.save(Content.builder()
+                .id(id)
+                .contentTag(contentTag)
+                .build());
+
+        // when & then
+        assertAll(
+                () -> assertThat(content.getCreatedAt()).isNotNull(),
+                () -> assertThat(content.getUpdatedAt()).isNotNull()
+        );
+    }
+
+}


### PR DESCRIPTION
## 상세 내용
- @EnableJpaAuditing 애노테이션을 붙여주지 않아 발생한 오류였습니다.
- 이 애노테이션을 붙여야 스프링 데이터 JPA에서 제공하는 auditing 기능이 활성화됩니다.
- 하지만 SpringBootApplication 파일에 이 애노테이션을 붙이면 `metamodel must not be empty` 오류가 발생합니다.
- WebMvcTest에서는 엔티티빈들을 등록하지 않아서 발생하는 오류입니다.

Close #25
