### PR TITLE
feat: 알림 설정 조회 API를 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -30,16 +30,22 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<Content> contents;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "preference_id")
     private Preference preference;
 
     @Builder
-    public Member(String id, String name, String molluId, LocalDate birthday) {
+    public Member(String id, String name, String molluId, LocalDate birthday, Preference preference) {
         this.id = id;
         this.name = new Name(name);
         this.molluId = new MolluId(molluId);
         this.birthday = new Birthday(birthday);
+        setPreference(preference);
+    }
+
+    private void setPreference(Preference preference) {
+        this.preference = preference;
+        preference.setMember(this);
     }
 
     public boolean isSameId(String id) {

--- a/src/main/java/sleepy/mollu/server/member/domain/Preference.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Preference.java
@@ -33,4 +33,8 @@ public class Preference {
         this.molluAlarm = molluAlarm;
         this.contentAlarm = contentAlarm;
     }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/sleepy/mollu/server/member/preference/controller/PreferenceController.java
+++ b/src/main/java/sleepy/mollu/server/member/preference/controller/PreferenceController.java
@@ -5,11 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sleepy.mollu.server.member.preference.dto.PreferenceRequest;
+import sleepy.mollu.server.member.preference.dto.PreferenceResponse;
 import sleepy.mollu.server.member.preference.service.PreferenceService;
 import sleepy.mollu.server.oauth2.controller.annotation.Login;
 import sleepy.mollu.server.swagger.*;
@@ -34,5 +32,17 @@ public class PreferenceController {
         preferenceService.updatePreference(memberId, request);
 
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "알림 설정 조회")
+    @OkResponse
+    @BadRequestResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @InternalServerErrorResponse
+    @GetMapping
+    public ResponseEntity<PreferenceResponse> searchPreference(@Login String memberId) {
+
+        return ResponseEntity.ok().body(preferenceService.searchPreference(memberId));
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/preference/dto/PreferenceResponse.java
+++ b/src/main/java/sleepy/mollu/server/member/preference/dto/PreferenceResponse.java
@@ -1,0 +1,4 @@
+package sleepy.mollu.server.member.preference.dto;
+
+public record PreferenceResponse(boolean molluAlarm, boolean contentAlarm) {
+}

--- a/src/main/java/sleepy/mollu/server/member/preference/service/PreferenceService.java
+++ b/src/main/java/sleepy/mollu/server/member/preference/service/PreferenceService.java
@@ -1,8 +1,11 @@
 package sleepy.mollu.server.member.preference.service;
 
 import sleepy.mollu.server.member.preference.dto.PreferenceRequest;
+import sleepy.mollu.server.member.preference.dto.PreferenceResponse;
 
 public interface PreferenceService {
 
     void updatePreference(String memberId, PreferenceRequest request);
+
+    PreferenceResponse searchPreference(String memberId);
 }

--- a/src/main/java/sleepy/mollu/server/member/service/PreferenceServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/member/service/PreferenceServiceImpl.java
@@ -7,6 +7,7 @@ import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.domain.Preference;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.preference.dto.PreferenceRequest;
+import sleepy.mollu.server.member.preference.dto.PreferenceResponse;
 import sleepy.mollu.server.member.preference.exception.PreferenceNotFoundException;
 import sleepy.mollu.server.member.preference.service.PreferenceService;
 import sleepy.mollu.server.member.repository.MemberRepository;
@@ -30,5 +31,19 @@ public class PreferenceServiceImpl implements PreferenceService {
         }
 
         preference.update(request.molluAlarm(), request.contentAlarm());
+    }
+
+    @Override
+    public PreferenceResponse searchPreference(String memberId) {
+
+        final Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("[" + memberId + "]에 해당하는 멤버가 없습니다."));
+
+        final Preference preference = member.getPreference();
+        if (preference == null) {
+            throw new PreferenceNotFoundException("[" + memberId + "]와 연관된 알림 설정이 없습니다.");
+        }
+
+        return new PreferenceResponse(preference.isMolluAlarm(), preference.isContentAlarm());
     }
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/ApplePublicKeyResponse.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/ApplePublicKeyResponse.java
@@ -12,6 +12,12 @@ public class ApplePublicKeyResponse {
 
     private List<Key> keys;
 
+    public Optional<Key> getMatchedKeyBy(String kid, String alg) {
+        return this.keys.stream()
+                .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
+                .findFirst();
+    }
+
     @Getter
     public static class Key {
         private String kty;
@@ -20,11 +26,5 @@ public class ApplePublicKeyResponse {
         private String alg;
         private String n;
         private String e;
-    }
-
-    public Optional<Key> getMatchedKeyBy(String kid, String alg) {
-        return this.keys.stream()
-                .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
-                .findFirst();
     }
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
@@ -6,6 +6,7 @@ import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
 import org.springframework.stereotype.Service;
 import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.domain.Preference;
 import sleepy.mollu.server.member.dto.MemberBadRequestException;
 import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
@@ -58,11 +59,18 @@ public class OAuth2ServiceImpl implements OAuth2Service {
 
         final String memberId = getOAuth2MemberId(type, socialToken);
         validateMemberExists(memberId);
-        saveMember(memberId, request.name(), request.birthday(), request.molluId());
+        final Preference preference = getPreference();
+        saveMember(memberId, preference, request.name(), request.birthday(), request.molluId());
 
         final JwtToken jwtToken = jwtGenerator.generate(memberId, Set.of("member"));
-
         return new TokenResponse(jwtToken.accessToken(), jwtToken.refreshToken());
+    }
+
+    private Preference getPreference() {
+        return Preference.builder()
+                .molluAlarm(false)
+                .contentAlarm(false)
+                .build();
     }
 
     private void validateMemberExists(String memberId) {
@@ -71,13 +79,14 @@ public class OAuth2ServiceImpl implements OAuth2Service {
         }
     }
 
-    private void saveMember(String memberId, String name, LocalDate birthday, String molluId) {
+    private void saveMember(String memberId, Preference preference, String name, LocalDate birthday, String molluId) {
 
         memberRepository.save(Member.builder()
                 .id(memberId)
                 .name(name)
                 .birthday(birthday)
                 .molluId(molluId)
+                .preference(preference)
                 .build());
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,5 @@
 # Global Configuration
+
 springdoc:
   swagger-ui:
     path: "/swagger"
@@ -27,6 +28,8 @@ oauth2:
 spring:
   main:
     allow-bean-definition-overriding: true
+  profiles:
+    active: local
 
 ---
 

--- a/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
@@ -1,9 +1,7 @@
 package sleepy.mollu.server.content.controller;
 
-import online.partyrun.jwtmanager.JwtExtractor;
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
-import online.partyrun.jwtmanager.manager.JwtManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/sleepy/mollu/server/member/service/PreferenceServiceTest.java
+++ b/src/test/java/sleepy/mollu/server/member/service/PreferenceServiceTest.java
@@ -17,7 +17,6 @@ import sleepy.mollu.server.member.repository.MemberRepository;
 
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
@@ -1,0 +1,63 @@
+package sleepy.mollu.server.oauth2.service;
+
+import jakarta.persistence.EntityManager;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.member.dto.SignupRequest;
+import sleepy.mollu.server.member.repository.MemberRepository;
+import sleepy.mollu.server.oauth2.dto.TokenResponse;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@Transactional
+class OAuth2ServiceIntegrationTest {
+
+    @Autowired
+    private OAuth2Service oAuth2Service;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("[소셜 회원가입 서비스 호출시] 멤버와 함께 알림 설정도 함께 저장된다.")
+    void OAuth2ServiceIntegrationTest() throws Exception {
+        // given
+        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId");
+
+        // when
+        oAuth2Service.signup("test", "socialToken", request);
+
+        // then
+        assertThat(memberRepository.existsById("memberId")).isTrue();
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public OAuth2Client testOAuth2Client() {
+            return socialToken -> "memberId";
+        }
+    }
+
+}

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
@@ -1,32 +1,18 @@
 package sleepy.mollu.server.oauth2.service;
 
-import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.repository.MemberRepository;
-import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.time.LocalDate;
-import java.util.Map;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 @SpringBootTest
 @Transactional


### PR DESCRIPTION
## 상세 내용
- 알림 설정 엔티티를 구현하였습니다.
- 멤버와 알림 설정의 연관관계 매핑을 설정하였습니다.
- 알림 설정 조회 API를 구현하였습니다.
- 회원가입시 알림 설정 엔티티도 함께 저장하도록 하였습니다.

Close #33 
