### PR TITLE
feat: 프로필 수정 API를 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
@@ -13,6 +13,7 @@ import sleepy.mollu.server.member.domain.Member;
 public class Content extends BaseEntity {
 
     @Id
+    @Column(name = "content_id")
     private String id;
 
     @Embedded

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sleepy.mollu.server.content.domain.content.Content;
+import sleepy.mollu.server.content.domain.content.ContentSource;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -26,6 +27,10 @@ public class Member {
 
     @Embedded
     private Birthday birthday;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "profile_source"))
+    private ContentSource profileSource;
 
     @OneToMany(mappedBy = "member")
     private List<Content> contents;
@@ -62,5 +67,25 @@ public class Member {
 
     public LocalDate getBirthday() {
         return this.birthday.getDate();
+    }
+
+    public String getProfileSource() {
+        return this.profileSource.getValue();
+    }
+
+    public void updateMolluId(String molluId) {
+        this.molluId = new MolluId(molluId);
+    }
+
+    public void updateName(String name) {
+        this.name = new Name(name);
+    }
+
+    public void updateBirthday(LocalDate birthday) {
+        this.birthday = new Birthday(birthday);
+    }
+
+    public void updateProfileSource(String profileSource) {
+        this.profileSource = new ContentSource(profileSource);
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/profile/controller/ProfileController.java
+++ b/src/main/java/sleepy/mollu/server/member/profile/controller/ProfileController.java
@@ -4,16 +4,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import sleepy.mollu.server.member.profile.dto.ProfileRequest;
 import sleepy.mollu.server.member.profile.dto.ProfileResponse;
 import sleepy.mollu.server.member.profile.service.ProfileService;
 import sleepy.mollu.server.oauth2.controller.annotation.Login;
 import sleepy.mollu.server.swagger.*;
 
-@RestController
 @Tag(name = "알림 설정 관련 API")
+@RestController
 @RequestMapping("/members/profile")
 @RequiredArgsConstructor
 public class ProfileController {
@@ -29,5 +28,18 @@ public class ProfileController {
     public ResponseEntity<ProfileResponse> searchProfile(@Login String memberId) {
 
         return ResponseEntity.ok().body(profileService.searchProfile(memberId));
+    }
+
+    @Operation(summary = "프로필 변경")
+    @OkResponse
+    @BadRequestResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @InternalServerErrorResponse
+    @PatchMapping
+    public ResponseEntity<Void> updateProfile(@Login String memberId, @ModelAttribute ProfileRequest request) {
+
+        profileService.updateProfile(memberId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/profile/dto/ProfileRequest.java
+++ b/src/main/java/sleepy/mollu/server/member/profile/dto/ProfileRequest.java
@@ -1,0 +1,8 @@
+package sleepy.mollu.server.member.profile.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+public record ProfileRequest(String molluId, String name, LocalDate birthday, MultipartFile profileFile) {
+}

--- a/src/main/java/sleepy/mollu/server/member/profile/dto/ProfileResponse.java
+++ b/src/main/java/sleepy/mollu/server/member/profile/dto/ProfileResponse.java
@@ -2,5 +2,5 @@ package sleepy.mollu.server.member.profile.dto;
 
 import java.time.LocalDate;
 
-public record ProfileResponse(String memberId, String molluId, String name, LocalDate birthday) {
+public record ProfileResponse(String memberId, String molluId, String name, LocalDate birthday, String profileSource) {
 }

--- a/src/main/java/sleepy/mollu/server/member/profile/service/ProfileService.java
+++ b/src/main/java/sleepy/mollu/server/member/profile/service/ProfileService.java
@@ -1,8 +1,11 @@
 package sleepy.mollu.server.member.profile.service;
 
+import sleepy.mollu.server.member.profile.dto.ProfileRequest;
 import sleepy.mollu.server.member.profile.dto.ProfileResponse;
 
 public interface ProfileService {
 
     ProfileResponse searchProfile(String memberId);
+
+    void updateProfile(String memberId, ProfileRequest request);
 }

--- a/src/main/java/sleepy/mollu/server/member/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/member/profile/service/ProfileServiceImpl.java
@@ -3,10 +3,16 @@ package sleepy.mollu.server.member.profile.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import sleepy.mollu.server.content.domain.file.ImageContentFile;
+import sleepy.mollu.server.content.domain.handler.FileHandler;
 import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
+import sleepy.mollu.server.member.profile.dto.ProfileRequest;
 import sleepy.mollu.server.member.profile.dto.ProfileResponse;
 import sleepy.mollu.server.member.repository.MemberRepository;
+
+import java.time.LocalDate;
 
 @Service
 @Transactional
@@ -14,13 +20,57 @@ import sleepy.mollu.server.member.repository.MemberRepository;
 public class ProfileServiceImpl implements ProfileService {
 
     private final MemberRepository memberRepository;
+    private final FileHandler fileHandler;
 
     @Override
     public ProfileResponse searchProfile(String memberId) {
 
-        final Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("ID가 [" + memberId + "]인 멤버를 찾을 수 없습니다."));
+        final Member member = getMember(memberId);
 
-        return new ProfileResponse(memberId, member.getMolluId(), member.getName(), member.getBirthday());
+        return new ProfileResponse(memberId, member.getMolluId(), member.getName(), member.getBirthday(),
+                member.getProfileSource());
     }
+
+    private Member getMember(String memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("ID가 [" + memberId + "]인 멤버를 찾을 수 없습니다."));
+    }
+
+    @Override
+    public void updateProfile(String memberId, ProfileRequest request) {
+
+        final Member member = getMember(memberId);
+
+        updateMolluId(member, request.molluId());
+        updateName(member, request.name());
+        updateBirthday(member, request.birthday());
+        updateProfile(member, request.profileFile());
+    }
+
+    private void updateMolluId(Member member, String molluId) {
+        if (molluId != null) {
+            member.updateMolluId(molluId);
+        }
+    }
+
+    private void updateName(Member member, String name) {
+        if (name != null) {
+            member.updateName(name);
+        }
+    }
+
+    private void updateBirthday(Member member, LocalDate birthday) {
+        if (birthday != null) {
+            member.updateBirthday(birthday);
+        }
+    }
+
+    private void updateProfile(Member member, MultipartFile profileFile) {
+        if (profileFile != null) {
+            final ImageContentFile contentFile = new ImageContentFile(profileFile);
+            final String profileFileUrl = fileHandler.upload(contentFile);
+            member.updateProfileSource(profileFileUrl);
+        }
+    }
+
 }

--- a/src/test/java/sleepy/mollu/server/member/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/member/profile/controller/ProfileControllerTest.java
@@ -1,0 +1,71 @@
+package sleepy.mollu.server.member.profile.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.partyrun.jwtmanager.JwtGenerator;
+import online.partyrun.jwtmanager.dto.JwtToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import sleepy.mollu.server.member.profile.service.ProfileService;
+import sleepy.mollu.server.oauth2.config.CustomJwtConfig;
+
+import java.util.Set;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProfileController.class)
+@Import(CustomJwtConfig.class)
+class ProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ProfileService profileService;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Nested
+    @DisplayName("[프로필 수정 API 호출 시] ")
+    class UpdateProfileTest {
+
+        @Test
+        @DisplayName("일부 데이터만 넣어서 전송해도 200을 반환한다.")
+        void updateProfileTest() throws Exception {
+            // given
+            final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("molluId", "ysyss");
+
+            final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
+            final String accessToken = jwtToken.accessToken();
+            final HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + accessToken);
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(multipart(HttpMethod.PATCH, "/members/profile")
+                    .headers(headers)
+                    .params(params));
+
+            // then
+            resultActions.andExpect(status().isOk())
+                    .andDo(print());
+        }
+    }
+
+}


### PR DESCRIPTION
## 상세 내용
- 프로필 수정 API를 구현하였습니다.
- Patch와 Put 중 고민하였지만, 멤버의 프로필 정보를 한번에 변경하는 일은 거의 없을 것으로 판단하여 HTTP method를 `Patch`로 결정하였습니다.

Close #32 
