### PR TITLE
bug: 프로필 조회 API 오류를 해결한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -30,7 +30,7 @@ public class Member {
 
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "profile_source"))
-    private ContentSource profileSource;
+    private ContentSource profileSource = new ContentSource("");
 
     @OneToMany(mappedBy = "member")
     private List<Content> contents;

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
@@ -7,12 +7,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.repository.MemberRepository;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 @Transactional
@@ -28,14 +30,23 @@ class OAuth2ServiceIntegrationTest {
     @DisplayName("[소셜 회원가입 서비스 호출시] 멤버와 함께 알림 설정도 함께 저장된다.")
     void OAuth2ServiceIntegrationTest() throws Exception {
         // given
+        final String EMPTY_SOURCE = "";
         final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId");
 
         // when
         oAuth2Service.signup("test", "socialToken", request);
 
         // then
-        assertThat(memberRepository.existsById("memberId")).isTrue();
+        final Member member = memberRepository.findById("memberId")
+                .orElseThrow();
+
+        assertAll(
+                () -> assertThat(member.getPreference()).isNotNull(),
+                () -> assertThat(member.getProfileSource()).isEqualTo(EMPTY_SOURCE)
+        );
+
     }
+
 
     @TestConfiguration
     static class TestConfig {


### PR DESCRIPTION
## 상세 내용
- `Cannot invoke "sleepy.mollu.server.content.domain.content.ContentSource.getValue()" because "this.profileSource" is null` 오류를
- 멤버 엔티티의 디폴트 프로필 사진 주소를 설정함으로써 오류를 해결하였습니다.

Close #43 
