### PR TITLE
feat: 컨텐츠 신고 API를 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
@@ -38,7 +38,7 @@ public class Content extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "content")
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
     private List<ContentReport> reports = new ArrayList<>();
 
 
@@ -68,6 +68,11 @@ public class Content extends BaseEntity {
         return location.getValue();
     }
 
+    public void addReport(ContentReport report) {
+        this.reports.add(report);
+        report.assignContent(this);
+    }
+
     public void updateUrl(String frontContentSource, String backContentSource) {
         this.frontContentSource = new ContentSource(frontContentSource);
         this.backContentSource = new ContentSource(backContentSource);
@@ -75,5 +80,9 @@ public class Content extends BaseEntity {
 
     public boolean isOwner(String memberId) {
         return this.member.isSameId(memberId);
+    }
+
+    public boolean isOwner(Member member) {
+        return this.member == member;
     }
 }

--- a/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
@@ -5,7 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
+import sleepy.mollu.server.content.report.domain.ContentReport;
 import sleepy.mollu.server.member.domain.Member;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -33,6 +37,10 @@ public class Content extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "content")
+    private List<ContentReport> reports = new ArrayList<>();
+
 
     @Builder
     public Content(String id, String contentTag, String frontContentSource, String backContentSource, String location, Member member) {

--- a/src/main/java/sleepy/mollu/server/content/report/controller/ContentReportController.java
+++ b/src/main/java/sleepy/mollu/server/content/report/controller/ContentReportController.java
@@ -1,0 +1,36 @@
+package sleepy.mollu.server.content.report.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sleepy.mollu.server.content.report.dto.ReportRequest;
+import sleepy.mollu.server.content.report.service.ReportService;
+import sleepy.mollu.server.oauth2.controller.annotation.Login;
+import sleepy.mollu.server.swagger.*;
+
+@RestController
+@Tag(name = "컨텐츠 신고 관련 API")
+@RequestMapping("/contents")
+@RequiredArgsConstructor
+public class ContentReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "컨텐츠 신고")
+    @CreatedResponse
+    @BadRequestResponse
+    @UnAuthorizedResponse
+    @NotFoundResponse
+    @InternalServerErrorResponse
+    @PostMapping("/{contentId}/report")
+    public ResponseEntity<Void> groupSearchFeedResponse(@Login String memberId, @PathVariable String contentId,
+                                                        @RequestBody(required = false) ReportRequest request) {
+
+        reportService.reportContent(memberId, contentId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
@@ -4,12 +4,27 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import sleepy.mollu.server.content.domain.content.Content;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class ContentReport extends Report {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "content_id")
     private Content content;
+
+    @Builder
+    public ContentReport(String reason, Content content) {
+        super(reason);
+        this.content = content;
+    }
+
+    public void assignContent(Content content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
@@ -1,0 +1,15 @@
+package sleepy.mollu.server.content.report.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import sleepy.mollu.server.content.domain.content.Content;
+
+@Entity
+public class ContentReport extends Report {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+}

--- a/src/main/java/sleepy/mollu/server/content/report/domain/Reason.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/Reason.java
@@ -1,8 +1,14 @@
 package sleepy.mollu.server.content.report.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Reason {
 
     private String value;

--- a/src/main/java/sleepy/mollu/server/content/report/domain/Reason.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/Reason.java
@@ -1,0 +1,9 @@
+package sleepy.mollu.server.content.report.domain;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Reason {
+
+    private String value;
+}

--- a/src/main/java/sleepy/mollu/server/content/report/domain/Report.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/Report.java
@@ -2,24 +2,34 @@ package sleepy.mollu.server.content.report.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
 import sleepy.mollu.server.member.domain.Member;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
 @Getter
+@NoArgsConstructor
 public abstract class Report extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
-    private Long id;
+    protected Long id;
 
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "content_report_reason"))
-    private Reason reason;
+    protected Reason reason;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    protected Report(String reason) {
+        this.reason = new Reason(reason);
+    }
+
+    public void assignMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/sleepy/mollu/server/content/report/domain/Report.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/Report.java
@@ -1,0 +1,25 @@
+package sleepy.mollu.server.content.report.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import sleepy.mollu.server.common.domain.BaseEntity;
+import sleepy.mollu.server.member.domain.Member;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+public abstract class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "content_report_reason"))
+    private Reason reason;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/sleepy/mollu/server/content/report/dto/ReportRequest.java
+++ b/src/main/java/sleepy/mollu/server/content/report/dto/ReportRequest.java
@@ -1,0 +1,4 @@
+package sleepy.mollu.server.content.report.dto;
+
+public record ReportRequest(String reason) {
+}

--- a/src/main/java/sleepy/mollu/server/content/report/exception/ReportBadRequestException.java
+++ b/src/main/java/sleepy/mollu/server/content/report/exception/ReportBadRequestException.java
@@ -1,0 +1,10 @@
+package sleepy.mollu.server.content.report.exception;
+
+import sleepy.mollu.server.common.exception.BadRequestException;
+
+public class ReportBadRequestException extends BadRequestException {
+
+    public ReportBadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sleepy/mollu/server/content/report/service/ReportService.java
+++ b/src/main/java/sleepy/mollu/server/content/report/service/ReportService.java
@@ -1,0 +1,8 @@
+package sleepy.mollu.server.content.report.service;
+
+import sleepy.mollu.server.content.report.dto.ReportRequest;
+
+public interface ReportService {
+
+    void reportContent(String memberId, String contentId, ReportRequest request);
+}

--- a/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
@@ -1,0 +1,21 @@
+package sleepy.mollu.server.content.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.content.report.dto.ReportRequest;
+import sleepy.mollu.server.content.repository.ContentRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ContentRepository contentRepository;
+
+    @Override
+    public void reportContent(String memberId, String contentId, ReportRequest request) {
+
+
+    }
+}

--- a/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
@@ -3,19 +3,55 @@ package sleepy.mollu.server.content.report.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.content.domain.content.Content;
+import sleepy.mollu.server.content.report.domain.ContentReport;
 import sleepy.mollu.server.content.report.dto.ReportRequest;
+import sleepy.mollu.server.content.report.exception.ReportBadRequestException;
 import sleepy.mollu.server.content.repository.ContentRepository;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.exception.MemberNotFoundException;
+import sleepy.mollu.server.member.repository.MemberRepository;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ReportServiceImpl implements ReportService {
 
+    private final MemberRepository memberRepository;
     private final ContentRepository contentRepository;
 
     @Override
     public void reportContent(String memberId, String contentId, ReportRequest request) {
 
+        final Member member = getMember(memberId);
+        final Content content = getContent(contentId);
+        validateOwner(member, content);
 
+        final ContentReport report = getContentReport(request.reason());
+
+        member.addContentReport(report);
+        content.addReport(report);
+    }
+
+    private Member getMember(String memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("ID가 [" + memberId + "]인 멤버를 찾을 수 없습니다."));
+    }
+
+    private Content getContent(String contentId) {
+        return contentRepository.findById(contentId)
+                .orElseThrow(() -> new MemberNotFoundException("ID가 [" + contentId + "]인 컨텐츠를 찾을 수 없습니다."));
+    }
+
+    private void validateOwner(Member member, Content content) {
+        if (content.isOwner(member)) {
+            throw new ReportBadRequestException("자신의 컨텐츠는 신고할 수 없습니다.");
+        }
+    }
+
+    private ContentReport getContentReport(String reason) {
+        return ContentReport.builder()
+                .reason(reason)
+                .build();
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
 import sleepy.mollu.server.content.domain.content.Content;
 import sleepy.mollu.server.content.domain.content.ContentSource;
+import sleepy.mollu.server.content.report.domain.ContentReport;
 import sleepy.mollu.server.content.report.domain.Report;
 
 import java.time.LocalDate;
@@ -42,8 +43,8 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "preference_id")
     private Preference preference;
 
-    @OneToMany(mappedBy = "member")
-    private List<Report> reports = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Report> contentReports = new ArrayList<>();
 
     @Builder
     public Member(String id, String name, String molluId, LocalDate birthday, Preference preference) {
@@ -56,7 +57,12 @@ public class Member extends BaseEntity {
 
     private void setPreference(Preference preference) {
         this.preference = preference;
-        preference.setMember(this);
+        preference.assignMember(this);
+    }
+
+    public void addContentReport(ContentReport contentReport) {
+        this.contentReports.add(contentReport);
+        contentReport.assignMember(this);
     }
 
     public boolean isSameId(String id) {

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -4,16 +4,19 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sleepy.mollu.server.common.domain.BaseEntity;
 import sleepy.mollu.server.content.domain.content.Content;
 import sleepy.mollu.server.content.domain.content.ContentSource;
+import sleepy.mollu.server.content.report.domain.Report;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @Column(name = "member_id")
@@ -33,11 +36,14 @@ public class Member {
     private ContentSource profileSource = new ContentSource("");
 
     @OneToMany(mappedBy = "member")
-    private List<Content> contents;
+    private List<Content> contents = new ArrayList<>();
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "preference_id")
     private Preference preference;
+
+    @OneToMany(mappedBy = "member")
+    private List<Report> reports = new ArrayList<>();
 
     @Builder
     public Member(String id, String name, String molluId, LocalDate birthday, Preference preference) {

--- a/src/main/java/sleepy/mollu/server/member/domain/Preference.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Preference.java
@@ -35,7 +35,7 @@ public class Preference extends BaseEntity {
         this.contentAlarm = contentAlarm;
     }
 
-    public void setMember(Member member) {
+    public void assignMember(Member member) {
         this.member = member;
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/domain/Preference.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Preference.java
@@ -4,11 +4,12 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sleepy.mollu.server.common.domain.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Preference {
+public class Preference extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/sleepy/mollu/server/content/report/controller/ContentReportControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/report/controller/ContentReportControllerTest.java
@@ -1,0 +1,62 @@
+package sleepy.mollu.server.content.report.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import online.partyrun.jwtmanager.JwtGenerator;
+import online.partyrun.jwtmanager.dto.JwtToken;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import sleepy.mollu.server.content.report.service.ReportService;
+import sleepy.mollu.server.oauth2.config.CustomJwtConfig;
+
+import java.util.Set;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ContentReportController.class)
+@Import(CustomJwtConfig.class)
+class ContentReportControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReportService reportService;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;
+
+    @Nested
+    @DisplayName("[컨텐츠 신고 API 호출시] ")
+    class ReportContentTest {
+
+        @Test
+        @DisplayName("신고 사유를 적지 않아도 201을 응답한다.")
+        void reportContentTest() throws Exception {
+            // given
+            final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
+            final String accessToken = jwtToken.accessToken();
+            final HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + accessToken);
+
+            final String contentId = "contentId";
+
+            // when
+            final ResultActions result = mockMvc.perform(post("/contents/" + contentId + "/report")
+                    .headers(headers));
+
+            // then
+            result.andExpect(status().isCreated())
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/sleepy/mollu/server/content/report/service/ReportServiceIntegrationTest.java
+++ b/src/test/java/sleepy/mollu/server/content/report/service/ReportServiceIntegrationTest.java
@@ -1,0 +1,82 @@
+package sleepy.mollu.server.content.report.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.content.domain.content.Content;
+import sleepy.mollu.server.content.report.domain.ContentReport;
+import sleepy.mollu.server.content.report.domain.Report;
+import sleepy.mollu.server.content.report.dto.ReportRequest;
+import sleepy.mollu.server.content.repository.ContentRepository;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.domain.Preference;
+import sleepy.mollu.server.member.repository.MemberRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+class ReportServiceIntegrationTest {
+
+    @Autowired
+    private ReportService reportService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ContentRepository contentRepository;
+
+    @Test
+    @DisplayName("[컨텐츠 신고 서비스 호출 시] 신고 엔티티가 저장된다.")
+    @Rollback(false)
+    void ReportServiceIntegrationTest() {
+        // given
+        final Preference preference = Preference.builder()
+                .molluAlarm(true)
+                .contentAlarm(true)
+                .build();
+
+        final Member member = memberRepository.save(Member.builder()
+                .id("memberId")
+                .name("name")
+                .birthday(LocalDate.now())
+                .molluId("molluId")
+                .preference(preference)
+                .build());
+
+        final Member member2 = memberRepository.save(Member.builder()
+                .id("memberId2")
+                .name("name")
+                .birthday(LocalDate.now())
+                .molluId("molluId")
+                .preference(preference)
+                .build());
+
+        final Content content = contentRepository.save(Content.builder()
+                .id("contentId")
+                .member(member)
+                .contentTag("tag")
+                .build());
+
+        // when
+        reportService.reportContent("memberId2", "contentId", new ReportRequest("reason"));
+
+        final List<Report> memberContentReports = member2.getContentReports();
+        final List<ContentReport> contentReports = content.getReports();
+
+        // then
+        assertAll(
+                () -> assertThat(memberContentReports).hasSize(1),
+                () -> assertThat(contentReports).hasSize(1)
+        );
+    }
+
+}


### PR DESCRIPTION
## 상세 내용
- Report 엔티티를 추상화하여 ContentReport 엔티티가 Report 엔티티를 상속하도록 하였습니다.
- CommentReport 엔티티도 Report 엔티티를 상속하면 됩니다.
- 양방향 연관관계를 편리하게 이용하기 위해 편의 메서드를 추가하였습니다.
- 편의 메서드는 중심 엔티티(Member, Content...)에 두려고 합니다.

Close #35 
