### PR TITLE
refactor: 애플 로그인을 리팩토링한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/oauth2/service/ApplePublicKeyResponse.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/ApplePublicKeyResponse.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.NoSuchElementException;
 
 @Getter
 @NoArgsConstructor
@@ -12,10 +12,11 @@ public class ApplePublicKeyResponse {
 
     private List<Key> keys;
 
-    public Optional<Key> getMatchedKeyBy(String kid, String alg) {
+    public Key getMatchedPublicKeyBy(String kid, String alg) {
         return this.keys.stream()
                 .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
-                .findFirst();
+                .findFirst()
+                .orElseThrow(() -> new NoSuchElementException("매칭되는 키를 찾을 수 없습니다."));
     }
 
     @Getter


### PR DESCRIPTION
## 상세 내용
- `AppleIdentityTokenVerifier`를 리팩토링하였습니다.
- 40줄의 메서드를 여러 개의 의미있는 이름의 메서드로 분리하였습니다.

Close #46 
