### PR TITLE
bug: DDL 생성 오류를 해결한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/group/domain/group/Group.java
+++ b/src/main/java/sleepy/mollu/server/group/domain/group/Group.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "groups")
+@Table(name = "`group`")
 @Getter
 @NoArgsConstructor
 public class Group {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 ---
 


### PR DESCRIPTION
## 상세 내용
- MySQL에서 Group(s)는 예약어이므로 테이블명에 백틱을 붙여 문제를 해결하였습니다.

Close #54 
