### PR TITLE
fix: 로그가 생성되는 위치를 절대 경로로 변경한다.

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOGS_ABSOLUTE_PATH" value="./logs"/>
+    <property name="LOGS_ABSOLUTE_PATH" value="/home/ubuntu/mollu/logs"/>
     <property name="PROFILE" value="${spring.profiles.active}"/>
     <property name="LOGS_FILE_PATH" value="${LOGS_ABSOLUTE_PATH}/${PROFILE}"/>
     <property name="LOGS_ROLLING_PATH" value="${LOGS_FILE_PATH}/was-logs"/>


### PR DESCRIPTION
## 상세 내용
- `logback-spring.xml`에서 로그가 생성되는 위치를 절대 경로로 변경하였습니다.
- `./logs`에서 `/home/ubuntu/mollu/logs`로 변경하였습니다.
- 상대 경로로 지정하면 `/opt/codedeploy-agent/./logs`에 로그를 저장하려고 하기 때문입니다.
