### PR TITLE
feat: 아이디 중복 확인 API를 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/report/service/ReportServiceImpl.java
@@ -50,10 +50,10 @@ public class ReportServiceImpl implements ReportService {
 
     private Long saveContentReport(String reason, Member member, Content content) {
         return reportRepository.save(ContentReport.builder()
-                .reason(reason)
-                .member(member)
-                .content(content)
-                .build())
+                        .reason(reason)
+                        .member(member)
+                        .content(content)
+                        .build())
                 .getId();
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -1,7 +1,10 @@
 package sleepy.mollu.server.member.domain;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
 import sleepy.mollu.server.common.domain.FileSource;
 import sleepy.mollu.server.content.domain.content.Content;

--- a/src/main/java/sleepy/mollu/server/member/domain/MolluId.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/MolluId.java
@@ -12,7 +12,7 @@ public class MolluId {
 
     private static final int MAX_MOLLU_ID_LENGTH = 20;
 
-    @Column(name = "mollu_id")
+    @Column(name = "mollu_id", unique = true)
     private String value;
 
     public MolluId(String value) {

--- a/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
+++ b/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
@@ -1,7 +1,12 @@
 package sleepy.mollu.server.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import sleepy.mollu.server.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
+
+    @Query("select case when count(m) > 0 then true else false end from Member m where m.molluId.value = :molluId")
+    boolean existsByMolluId(@Param("molluId") String molluId);
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
@@ -8,10 +8,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.oauth2.controller.annotation.SocialToken;
+import sleepy.mollu.server.oauth2.dto.CheckResponse;
 import sleepy.mollu.server.oauth2.dto.TokenResponse;
 import sleepy.mollu.server.oauth2.service.OAuth2Service;
 import sleepy.mollu.server.swagger.CreatedResponse;
 import sleepy.mollu.server.swagger.InternalServerErrorResponse;
+import sleepy.mollu.server.swagger.OkResponse;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -44,5 +46,14 @@ public class OAuth2Controller {
             @RequestBody @Valid SignupRequest request) throws GeneralSecurityException, IOException {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(oauth2Service.signup(type, socialToken, request));
+    }
+
+    @Operation(summary = "아이디 중복 확인")
+    @OkResponse
+    @InternalServerErrorResponse
+    @PostMapping("/check-id")
+    public ResponseEntity<CheckResponse> signup(@RequestParam String molluId) {
+
+        return ResponseEntity.ok().body(oauth2Service.checkId(molluId));
     }
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/dto/CheckResponse.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/dto/CheckResponse.java
@@ -1,0 +1,4 @@
+package sleepy.mollu.server.oauth2.dto;
+
+public record CheckResponse(boolean isAvailable) {
+}

--- a/src/main/java/sleepy/mollu/server/oauth2/service/AppleIdentityTokenVerifier.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/AppleIdentityTokenVerifier.java
@@ -54,7 +54,8 @@ public class AppleIdentityTokenVerifier {
         final String decodedHeaderJson = new String(decodedHeader, StandardCharsets.UTF_8);
 
         final ObjectMapper objectMapper = new ObjectMapper();
-        return objectMapper.readValue(decodedHeaderJson, new TypeReference<Map<String, String>>() {});
+        return objectMapper.readValue(decodedHeaderJson, new TypeReference<Map<String, String>>() {
+        });
     }
 
     private PublicKey getAppleRSAPublicKey(String encodedN, String encodedE, String algorithm) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2Service.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2Service.java
@@ -1,6 +1,7 @@
 package sleepy.mollu.server.oauth2.service;
 
 import sleepy.mollu.server.member.dto.SignupRequest;
+import sleepy.mollu.server.oauth2.dto.CheckResponse;
 import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
@@ -11,4 +12,6 @@ public interface OAuth2Service {
     TokenResponse login(String type, String socialToken) throws GeneralSecurityException, IOException;
 
     TokenResponse signup(String type, String socialToken, SignupRequest request) throws GeneralSecurityException, IOException;
+
+    CheckResponse checkId(String molluId);
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
@@ -18,6 +18,7 @@ import sleepy.mollu.server.member.dto.MemberBadRequestException;
 import sleepy.mollu.server.member.dto.SignupRequest;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.repository.MemberRepository;
+import sleepy.mollu.server.oauth2.dto.CheckResponse;
 import sleepy.mollu.server.oauth2.dto.TokenResponse;
 
 import java.io.IOException;
@@ -114,5 +115,13 @@ public class OAuth2ServiceImpl implements OAuth2Service {
     private Group getGroup() {
         return groupRepository.findDefaultGroup()
                 .orElseThrow(() -> new GroupNotFoundException("디폴트 그룹을 찾을 수 없습니다."));
+    }
+
+    @Override
+    public CheckResponse checkId(String molluId) {
+
+        final boolean existsMemberWithSameMolluId = memberRepository.existsByMolluId(molluId);
+        
+        return new CheckResponse(!existsMemberWithSameMolluId);
     }
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
@@ -121,7 +121,7 @@ public class OAuth2ServiceImpl implements OAuth2Service {
     public CheckResponse checkId(String molluId) {
 
         final boolean existsMemberWithSameMolluId = memberRepository.existsByMolluId(molluId);
-        
+
         return new CheckResponse(!existsMemberWithSameMolluId);
     }
 }

--- a/src/test/java/sleepy/mollu/server/content/report/controller/ContentReportControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/report/controller/ContentReportControllerTest.java
@@ -1,6 +1,5 @@
 package sleepy.mollu.server.content.report.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,66 @@
+package sleepy.mollu.server.member.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.domain.Preference;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = MemberRepository.class))
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("[existsByMolluId 호출시] 동일한 molluId를 가진 멤버가 존재하면 true를 반환한다.")
+    void MemberRepositoryTest() {
+        // given
+        final String sameMolluId = "molluId";
+        saveMember(sameMolluId);
+
+        // when
+        final boolean exists = memberRepository.existsByMolluId(sameMolluId);
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("[existsByMolluId 호출시] 동일한 molluId를 가진 멤버가 없으면 false를 반환한다.")
+    void MemberRepositoryTest2() {
+        // given
+        final String saveMolluId = "saveMolluId";
+        final String checkMolluId = "checkMolluId";
+        saveMember(saveMolluId);
+
+        // when
+        final boolean exists = memberRepository.existsByMolluId(checkMolluId);
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    private void saveMember(String molluId) {
+        final Preference preference = Preference.builder()
+                .molluAlarm(true)
+                .contentAlarm(true)
+                .build();
+
+        memberRepository.save(Member.builder()
+                .id("memberId")
+                .molluId(molluId)
+                .name("name")
+                .birthday(LocalDate.now())
+                .preference(preference)
+                .build());
+    }
+}

--- a/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
@@ -13,7 +13,7 @@ import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest(includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = MemberRepository.class))
+@DataJpaTest
 class MemberRepositoryTest {
 
     @Autowired

--- a/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
@@ -1,6 +1,5 @@
 package sleepy.mollu.server.member.repository;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
## 상세 내용
- 아이디 중복 확인 API를 구현하였습니다.
- 멤버 리포지토리에 molluId로 중복을 확인하는 메서드를 테스트 및 구현하였습니다.
- 테스트는 @DataJpaTest를 이용하여 작성하였습니다.
- 빠른 속도가 장점인 슬라이스 테스트입니다.

Close #63 
