### PR TITLE
fix: 아이디 중복 확인 API의 HTTP 메서드를 수정한다

### DIFF
--- a/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
@@ -11,6 +11,7 @@ import sleepy.mollu.server.oauth2.controller.annotation.SocialToken;
 import sleepy.mollu.server.oauth2.dto.CheckResponse;
 import sleepy.mollu.server.oauth2.dto.TokenResponse;
 import sleepy.mollu.server.oauth2.service.OAuth2Service;
+import sleepy.mollu.server.swagger.BadRequestResponse;
 import sleepy.mollu.server.swagger.CreatedResponse;
 import sleepy.mollu.server.swagger.InternalServerErrorResponse;
 import sleepy.mollu.server.swagger.OkResponse;
@@ -50,8 +51,9 @@ public class OAuth2Controller {
 
     @Operation(summary = "아이디 중복 확인")
     @OkResponse
+    @BadRequestResponse
     @InternalServerErrorResponse
-    @PostMapping("/check-id")
+    @GetMapping("/check-id")
     public ResponseEntity<CheckResponse> signup(@RequestParam String molluId) {
 
         return ResponseEntity.ok().body(oauth2Service.checkId(molluId));

--- a/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
@@ -17,6 +17,7 @@ import sleepy.mollu.server.oauth2.service.OAuth2Service;
 
 import java.time.LocalDate;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -89,6 +90,34 @@ class OAuth2ControllerTest {
 
             // then
             resultActions.andExpect(status().isCreated())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("[아이디 중복 확인 API 호출 시] ")
+    class CheckIdTest {
+
+        @Test
+        @DisplayName("파라미터를 설정하지 않으면 400을 반환한다")
+        void checkIdTest() throws Exception {
+            // given & when
+            final ResultActions resultActions = mockMvc.perform(get("/auth/check-id"));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("호출에 성공하면 200을 반환한다")
+        void checkIdTest1() throws Exception {
+            // given & when
+            final ResultActions resultActions = mockMvc.perform(get("/auth/check-id")
+                    .param("molluId", "molluId"));
+
+            // then
+            resultActions.andExpect(status().isOk())
                     .andDo(print());
         }
     }


### PR DESCRIPTION
## 상세 내용
- 아이디 중복 확인 API의 HTTP 메서드가 잘못되어 수정하였습니다.
- 컨트롤러 구현시 컨트롤러 테스트를 작성해야 합니다.
