### PR TITLE
feat: 알림을 보내는 기능을 구현한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/ServerApplication.java
+++ b/src/main/java/sleepy/mollu/server/ServerApplication.java
@@ -2,8 +2,10 @@ package sleepy.mollu.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarm.java
+++ b/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarm.java
@@ -1,0 +1,40 @@
+package sleepy.mollu.server.alarm.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sleepy.mollu.server.common.domain.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MolluAlarm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime molluTime;
+
+    private boolean send;
+
+    public MolluAlarm(LocalDateTime molluTime, boolean send) {
+        this.molluTime = molluTime;
+        this.send = send;
+    }
+
+    public boolean isToday(LocalDateTime now) {
+        return this.molluTime.getYear() == now.getYear() &&
+                this.molluTime.getMonth() == now.getMonth() &&
+                this.molluTime.getDayOfMonth() == now.getDayOfMonth();
+    }
+
+    public void updateSend() {
+        this.send = true;
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarmRange.java
+++ b/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarmRange.java
@@ -1,0 +1,29 @@
+package sleepy.mollu.server.alarm.domain;
+
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+public class MolluAlarmRange {
+
+    private static final MolluAlarmRange INSTANCE = new MolluAlarmRange();
+
+    private LocalTime from = LocalTime.of(10, 0);
+    private LocalTime to = LocalTime.of(22, 0);
+
+    private MolluAlarmRange() {}
+
+    public static MolluAlarmRange getInstance() {
+        return INSTANCE;
+    }
+
+    public boolean isInRange(LocalTime now) {
+        return now.isAfter(from) && now.isBefore(to);
+    }
+
+    public void update(LocalTime from, LocalTime to) {
+        this.from = from;
+        this.to = to;
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarmRange.java
+++ b/src/main/java/sleepy/mollu/server/alarm/domain/MolluAlarmRange.java
@@ -12,7 +12,8 @@ public class MolluAlarmRange {
     private LocalTime from = LocalTime.of(10, 0);
     private LocalTime to = LocalTime.of(22, 0);
 
-    private MolluAlarmRange() {}
+    private MolluAlarmRange() {
+    }
 
     public static MolluAlarmRange getInstance() {
         return INSTANCE;

--- a/src/main/java/sleepy/mollu/server/alarm/dto/FcmAlarmRequest.java
+++ b/src/main/java/sleepy/mollu/server/alarm/dto/FcmAlarmRequest.java
@@ -1,0 +1,10 @@
+package sleepy.mollu.server.alarm.dto;
+
+public record FcmAlarmRequest(String to, Notification notification, Data data) {
+
+    public record Notification(String title, String body) {
+    }
+
+    public record Data(String title, String body) {
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/dto/FcmAlarmResponse.java
+++ b/src/main/java/sleepy/mollu/server/alarm/dto/FcmAlarmResponse.java
@@ -1,0 +1,7 @@
+package sleepy.mollu.server.alarm.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FcmAlarmResponse(@JsonProperty("multicast_id") String multicastId, String success, String failure,
+                               @JsonProperty("canonical_ids") String canonicalId) {
+}

--- a/src/main/java/sleepy/mollu/server/alarm/exception/MolluAlarmNotFoundException.java
+++ b/src/main/java/sleepy/mollu/server/alarm/exception/MolluAlarmNotFoundException.java
@@ -1,0 +1,10 @@
+package sleepy.mollu.server.alarm.exception;
+
+import sleepy.mollu.server.common.exception.NotFoundException;
+
+public class MolluAlarmNotFoundException extends NotFoundException {
+
+    public MolluAlarmNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/repository/MolluAlarmRepository.java
+++ b/src/main/java/sleepy/mollu/server/alarm/repository/MolluAlarmRepository.java
@@ -1,0 +1,11 @@
+package sleepy.mollu.server.alarm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sleepy.mollu.server.alarm.domain.MolluAlarm;
+
+import java.util.Optional;
+
+public interface MolluAlarmRepository extends JpaRepository<MolluAlarm, Long> {
+
+    Optional<MolluAlarm> findTopByOrderByIdDesc();
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/AlarmClient.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/AlarmClient.java
@@ -1,0 +1,6 @@
+package sleepy.mollu.server.alarm.service;
+
+public interface AlarmClient {
+
+    void send(String to);
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/AlarmService.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/AlarmService.java
@@ -1,0 +1,6 @@
+package sleepy.mollu.server.alarm.service;
+
+public interface AlarmService {
+
+    void sendAlarm();
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/FcmAlarmClient.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/FcmAlarmClient.java
@@ -1,0 +1,44 @@
+package sleepy.mollu.server.alarm.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import sleepy.mollu.server.alarm.dto.FcmAlarmRequest;
+import sleepy.mollu.server.alarm.dto.FcmAlarmResponse;
+
+@Component
+public class FcmAlarmClient implements AlarmClient {
+
+    private static final RestTemplate REST_TEMPLATE = new RestTemplate();
+    private static final String FCM_URL = "https://fcm.googleapis.com/fcm/send";
+
+    @Value("${alarm.fcm.authorization-key}")
+    private String authorizationKey;
+
+    @Override
+    public void send(String to) {
+        final HttpHeaders headers = getHeaders();
+        FcmAlarmRequest request = getRequest(to);
+        final HttpEntity<FcmAlarmRequest> requestEntity = new HttpEntity<>(request, headers);
+
+        REST_TEMPLATE.postForEntity(FCM_URL, requestEntity, FcmAlarmResponse.class);
+    }
+
+    private FcmAlarmRequest getRequest(String to) {
+        FcmAlarmRequest.Notification notification = new FcmAlarmRequest.Notification("title", "body");
+        FcmAlarmRequest.Data data = new FcmAlarmRequest.Data("title", "body");
+
+        return new FcmAlarmRequest(to, notification, data);
+    }
+
+    private HttpHeaders getHeaders() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "key=" + authorizationKey);
+
+        return headers;
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmScheduler.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmScheduler.java
@@ -17,13 +17,12 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MolluAlarmScheduler {
 
-    @Value("${spring.profiles.active}")
-    private String profile;
-
     private final MolluAlarmRepository molluAlarmRepository;
     private final TimePicker timePicker;
     private final TaskScheduler taskScheduler;
     private final AlarmService alarmService;
+    @Value("${spring.profiles.active}")
+    private String profile;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmScheduler.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmScheduler.java
@@ -1,0 +1,97 @@
+package sleepy.mollu.server.alarm.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import sleepy.mollu.server.alarm.domain.MolluAlarm;
+import sleepy.mollu.server.alarm.domain.MolluAlarmRange;
+import sleepy.mollu.server.alarm.repository.MolluAlarmRepository;
+
+import java.time.*;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class MolluAlarmScheduler {
+
+    @Value("${spring.profiles.active}")
+    private String profile;
+
+    private final MolluAlarmRepository molluAlarmRepository;
+    private final TimePicker timePicker;
+    private final TaskScheduler taskScheduler;
+    private final AlarmService alarmService;
+
+    @PostConstruct
+    public void init() {
+
+        if (!isValidProfile()) return;
+
+        final MolluAlarm molluAlarm = getMolluAlarm();
+        if (molluAlarm == null) return;
+        sendAlarm(molluAlarm);
+    }
+
+    private boolean isValidProfile() {
+        if (profile == null) return false;
+        final boolean isProfileDev = profile.equals("dev");
+        final boolean isProfileProd = profile.equals("prod");
+
+        return isProfileDev || isProfileProd;
+    }
+
+    private MolluAlarm getMolluAlarm() {
+        final Optional<MolluAlarm> newMolluAlarm = molluAlarmRepository.findTopByOrderByIdDesc();
+
+        if (newMolluAlarm.isEmpty()) {
+            generateAlarm();
+            scheduleAlarm();
+            return null;
+        }
+
+        return newMolluAlarm.get();
+    }
+
+    private void sendAlarm(MolluAlarm molluAlarm) {
+        if (!molluAlarm.isToday(LocalDateTime.now())) {
+            generateAlarm();
+        }
+
+        if (!molluAlarm.isSend()) {
+            scheduleAlarm();
+        }
+    }
+
+    private void generateAlarm() {
+        final MolluAlarmRange molluAlarmRange = MolluAlarmRange.getInstance();
+        final LocalTime sendTime = timePicker.pick(molluAlarmRange.getFrom(), molluAlarmRange.getTo());
+        final LocalDate currentDate = LocalDate.now();
+        final LocalDateTime molluTime = LocalDateTime.of(currentDate, sendTime);
+
+        molluAlarmRepository.save(new MolluAlarm(molluTime, false));
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    private void scheduleAlarm() {
+        final Instant startTime = getStartTime();
+
+        taskScheduler.schedule(this::sendAlarm, startTime);
+    }
+
+    private Instant getStartTime() {
+        final MolluAlarm molluAlarm = molluAlarmRepository.findTopByOrderByIdDesc()
+                .orElseThrow();
+        final LocalDateTime molluTime = molluAlarm.getMolluTime();
+        final ZoneId zoneId = ZoneId.systemDefault();
+        final ZonedDateTime zonedDateTime = molluTime.atZone(zoneId);
+
+        return zonedDateTime.toInstant();
+    }
+
+    private void sendAlarm() {
+        alarmService.sendAlarm();
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmService.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/MolluAlarmService.java
@@ -1,0 +1,33 @@
+package sleepy.mollu.server.alarm.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sleepy.mollu.server.alarm.domain.MolluAlarm;
+import sleepy.mollu.server.alarm.exception.MolluAlarmNotFoundException;
+import sleepy.mollu.server.alarm.repository.MolluAlarmRepository;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.repository.MemberRepository;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MolluAlarmService implements AlarmService  {
+
+    private final MolluAlarmRepository molluAlarmRepository;
+    private final MemberRepository memberRepository;
+    private final AlarmClient alarmClient;
+
+
+    @Override
+    public void sendAlarm() {
+        final MolluAlarm molluAlarm = molluAlarmRepository.findTopByOrderByIdDesc()
+                .orElseThrow(() -> new MolluAlarmNotFoundException("`MolluAlarm`이 존재하지 않습니다."));
+        molluAlarm.updateSend();
+
+        final List<Member> alarmAllowedMembers = memberRepository.findAllByMolluAlarmAllowed();
+        alarmAllowedMembers.forEach(member -> alarmClient.send(member.getPhoneToken()));
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/RandomTimePicker.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/RandomTimePicker.java
@@ -1,0 +1,23 @@
+package sleepy.mollu.server.alarm.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class RandomTimePicker implements TimePicker {
+
+    @Override
+    public LocalTime pick(LocalTime from, LocalTime to) {
+
+        if (from.isAfter(to)) {
+            throw new IllegalArgumentException("[from]은 [to]보다 이전 시각이어야 합니다.");
+        }
+
+        final int differenceSeconds = (int) from.until(to, ChronoUnit.SECONDS);
+        final long randomSeconds = (long) (Math.random() * differenceSeconds);
+
+        return from.plusSeconds(randomSeconds);
+    }
+}

--- a/src/main/java/sleepy/mollu/server/alarm/service/TimePicker.java
+++ b/src/main/java/sleepy/mollu/server/alarm/service/TimePicker.java
@@ -1,0 +1,9 @@
+package sleepy.mollu.server.alarm.service;
+
+import java.time.LocalTime;
+
+@FunctionalInterface
+public interface TimePicker {
+
+    LocalTime pick(LocalTime from, LocalTime to);
+}

--- a/src/main/java/sleepy/mollu/server/common/domain/BaseEntity.java
+++ b/src/main/java/sleepy/mollu/server/common/domain/BaseEntity.java
@@ -15,8 +15,8 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 }

--- a/src/main/java/sleepy/mollu/server/common/interceptor/WebInterceptor.java
+++ b/src/main/java/sleepy/mollu/server/common/interceptor/WebInterceptor.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Map;
 
@@ -13,8 +12,13 @@ import java.util.Map;
 @Slf4j
 public class WebInterceptor implements HandlerInterceptor {
 
+    private static final String ATTRIBUTE_TIME = "time";
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        final long start = System.currentTimeMillis();
+        request.setAttribute(ATTRIBUTE_TIME, start);
+
         log.info("Request URI: {}, Method: {}", request.getRequestURI(), request.getMethod());
         final Map<String, String[]> parameterMap = request.getParameterMap();
         parameterMap.forEach((key, value) -> log.info("Request Parameter: {} = {}", key, value));
@@ -23,7 +27,12 @@ public class WebInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
         log.info("Response Status: {}", response.getStatus());
+
+        final long start = (long) request.getAttribute(ATTRIBUTE_TIME);
+        final long end = System.currentTimeMillis();
+
+        log.info("[" + handler + "] executeTime : " + (end - start) + "ms");
     }
 }

--- a/src/main/java/sleepy/mollu/server/member/domain/Member.java
+++ b/src/main/java/sleepy/mollu/server/member/domain/Member.java
@@ -34,6 +34,8 @@ public class Member extends BaseEntity {
     @Embedded
     private Birthday birthday;
 
+    private String phoneToken;
+
     @Embedded
     @AttributeOverride(name = "value", column = @Column(name = "profile_source"))
     private FileSource profileSource = new FileSource("");
@@ -52,11 +54,12 @@ public class Member extends BaseEntity {
     private List<GroupMember> groupMembers = new ArrayList<>();
 
     @Builder
-    public Member(String id, String name, String molluId, LocalDate birthday, Preference preference) {
+    public Member(String id, String name, String molluId, LocalDate birthday, String phoneToken, Preference preference) {
         this.id = id;
         this.name = new Name(name);
         this.molluId = new MolluId(molluId);
         this.birthday = new Birthday(birthday);
+        this.phoneToken = phoneToken;
         setPreference(preference);
     }
 

--- a/src/main/java/sleepy/mollu/server/member/dto/SignupRequest.java
+++ b/src/main/java/sleepy/mollu/server/member/dto/SignupRequest.java
@@ -4,5 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
-public record SignupRequest(@NotNull String name, @NotNull LocalDate birthday, @NotNull String molluId) {
+public record SignupRequest(@NotNull String name, @NotNull LocalDate birthday, @NotNull String molluId,
+                            @NotNull String phoneToken) {
 }

--- a/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
+++ b/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
@@ -5,8 +5,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import sleepy.mollu.server.member.domain.Member;
 
+import java.util.List;
+
 public interface MemberRepository extends JpaRepository<Member, String> {
 
     @Query("select case when count(m) > 0 then true else false end from Member m where m.molluId.value = :molluId")
     boolean existsByMolluId(@Param("molluId") String molluId);
+
+    @Query("select m from Member m join Preference p on m.preference = p where p.molluAlarm = true")
+    List<Member> findAllByMolluAlarmAllowed();
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceImpl.java
@@ -71,7 +71,7 @@ public class OAuth2ServiceImpl implements OAuth2Service {
 
         final String memberId = getOAuth2MemberId(type, socialToken);
         validateMemberExists(memberId);
-        final Member member = saveMember(memberId, request.name(), request.birthday(), request.molluId());
+        final Member member = saveMember(memberId, request.name(), request.birthday(), request.molluId(), request.phoneToken());
 
         // FIXME: 2023/07/25 MVP 이후 삭제
         joinGroup(member);
@@ -86,12 +86,13 @@ public class OAuth2ServiceImpl implements OAuth2Service {
         }
     }
 
-    private Member saveMember(String memberId, String name, LocalDate birthday, String molluId) {
+    private Member saveMember(String memberId, String name, LocalDate birthday, String molluId, String phoneToken) {
         return memberRepository.save(Member.builder()
                 .id(memberId)
                 .name(name)
                 .birthday(birthday)
                 .molluId(molluId)
+                .phoneToken(phoneToken)
                 .preference(getPreference())
                 .build());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,10 @@ spring:
   profiles:
     active: local
 
+alarm:
+  fcm:
+    authorization-key: ${FCM_AUTHORIZATION_KEY}
+
 ---
 
 # Local Configuration

--- a/src/test/java/sleepy/mollu/server/alarm/service/MolluAlarmSchedulerTest.java
+++ b/src/test/java/sleepy/mollu/server/alarm/service/MolluAlarmSchedulerTest.java
@@ -44,6 +44,12 @@ class MolluAlarmSchedulerTest {
     @Mock
     private AlarmService alarmService;
 
+    private void reflect(Object object, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(object, value);
+    }
+
     @Nested
     @DisplayName("[스케쥴러 실행시] ")
     class SchedulerTest {
@@ -142,12 +148,6 @@ class MolluAlarmSchedulerTest {
             // then
             then(alarmService).should(times(1)).sendAlarm();
         }
-    }
-
-    private void reflect(Object object, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
-        final Field field = object.getClass().getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(object, value);
     }
 
 }

--- a/src/test/java/sleepy/mollu/server/alarm/service/MolluAlarmSchedulerTest.java
+++ b/src/test/java/sleepy/mollu/server/alarm/service/MolluAlarmSchedulerTest.java
@@ -1,0 +1,153 @@
+package sleepy.mollu.server.alarm.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import sleepy.mollu.server.alarm.domain.MolluAlarm;
+import sleepy.mollu.server.alarm.repository.MolluAlarmRepository;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class MolluAlarmSchedulerTest {
+
+    @InjectMocks
+    private MolluAlarmScheduler molluAlarmScheduler;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private TimePicker timePicker;
+
+    @Mock
+    private MolluAlarmRepository molluAlarmRepository;
+
+    @Mock
+    private AlarmService alarmService;
+
+    @Nested
+    @DisplayName("[스케쥴러 실행시] ")
+    class SchedulerTest {
+
+        @ParameterizedTest
+        @ValueSource(strings = "local")
+        @NullAndEmptySource
+        @DisplayName("프로파일이 `dev` 또는 `prod`가 아니면 실행하지 않는다.")
+        void SchedulerTest(String profile) throws NoSuchFieldException, IllegalAccessException {
+            // given
+            reflect(molluAlarmScheduler, "profile", profile);
+
+            // when
+            molluAlarmScheduler.init();
+
+            // then
+            then(molluAlarmRepository).should(times(0)).findTopByOrderByIdDesc();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"dev", "prod"})
+        @DisplayName("어떤 알림도 생성되지 않았으면 새로운 알림을 생성하고, 알림을 예약한다.")
+        void SchedulerTest4(String profile) throws NoSuchFieldException, IllegalAccessException {
+            // given
+            reflect(molluAlarmScheduler, "profile", profile);
+            given(molluAlarmRepository.findTopByOrderByIdDesc()).willReturn(Optional.empty());
+            given(timePicker.pick(any(LocalTime.class), any(LocalTime.class))).willReturn(LocalTime.now());
+            final MolluAlarm molluAlarm = mock(MolluAlarm.class);
+            given(molluAlarmRepository.findTopByOrderByIdDesc()).willReturn(Optional.of(molluAlarm));
+            given(molluAlarm.getMolluTime()).willReturn(LocalDateTime.now());
+
+            // when
+            molluAlarmScheduler.init();
+
+            // then
+            then(molluAlarmRepository).should(times(1)).save(any(MolluAlarm.class));
+            then(taskScheduler).should(times(1)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"dev", "prod"})
+        @DisplayName("오늘 생성된 알림이 없으면 새로운 알림을 생성한다.")
+        void SchedulerTest2(String profile) throws NoSuchFieldException, IllegalAccessException {
+            // given
+            reflect(molluAlarmScheduler, "profile", profile);
+            final MolluAlarm molluAlarm = mock(MolluAlarm.class);
+            given(molluAlarmRepository.findTopByOrderByIdDesc()).willReturn(Optional.of(molluAlarm));
+            given(molluAlarm.isToday(any())).willReturn(false);
+            given(timePicker.pick(any(LocalTime.class), any(LocalTime.class))).willReturn(LocalTime.now());
+            given(molluAlarm.getMolluTime()).willReturn(LocalDateTime.now());
+
+            // when
+            molluAlarmScheduler.init();
+
+            // then
+            then(molluAlarmRepository).should(times(1)).save(any(MolluAlarm.class));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"dev", "prod"})
+        @DisplayName("오늘 이미 알람을 보냈다면 실행하지 않는다.")
+        void SchedulerTest3(String profile) throws NoSuchFieldException, IllegalAccessException {
+            // given
+            reflect(molluAlarmScheduler, "profile", profile);
+            final MolluAlarm molluAlarm = mock(MolluAlarm.class);
+            given(molluAlarmRepository.findTopByOrderByIdDesc()).willReturn(Optional.of(molluAlarm));
+            given(molluAlarm.isToday(any())).willReturn(true);
+            given(molluAlarm.isSend()).willReturn(true);
+
+            // when
+            molluAlarmScheduler.init();
+
+            // then
+            then(taskScheduler).should(times(0)).schedule(any(Runnable.class), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("알람을 성공적으로 보낸다.")
+        void SchedulerTest4() throws NoSuchFieldException, IllegalAccessException {
+            // given
+            reflect(molluAlarmScheduler, "profile", "dev");
+            final MolluAlarm molluAlarm = mock(MolluAlarm.class);
+            given(molluAlarmRepository.findTopByOrderByIdDesc()).willReturn(Optional.of(molluAlarm));
+            given(molluAlarm.isToday(any())).willReturn(true);
+            given(molluAlarm.isSend()).willReturn(false);
+            given(molluAlarm.getMolluTime()).willReturn(LocalDateTime.now());
+            given(taskScheduler.schedule(any(Runnable.class), any(Instant.class))).willAnswer(invocation -> {
+                final Runnable task = invocation.getArgument(0);
+                task.run();
+                return null;
+            });
+
+            // when
+            molluAlarmScheduler.init();
+
+            // then
+            then(alarmService).should(times(1)).sendAlarm();
+        }
+    }
+
+    private void reflect(Object object, String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(object, value);
+    }
+
+}

--- a/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/member/repository/MemberRepositoryTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
 import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.domain.Preference;
 

--- a/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/controller/OAuth2ControllerTest.java
@@ -78,7 +78,7 @@ class OAuth2ControllerTest {
             final HttpHeaders headers = new HttpHeaders();
             headers.add("Authorization", "Bearer " + "test_token");
 
-            final SignupRequest request = new SignupRequest("김준형", LocalDate.now(), "molluId");
+            final SignupRequest request = new SignupRequest("김준형", LocalDate.now(), "molluId", "phoneToken");
             final String requestBody = objectMapper.writeValueAsString(request);
 
             // when

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceIntegrationTest.java
@@ -31,7 +31,7 @@ class OAuth2ServiceIntegrationTest {
     void OAuth2ServiceIntegrationTest() throws Exception {
         // given
         final String EMPTY_SOURCE = "";
-        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId");
+        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId", "phoneToken");
 
         // when
         oAuth2Service.signup("test", "socialToken", request);

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceTest.java
@@ -116,7 +116,7 @@ class OAuth2ServiceTest {
 
         final String type = "type";
         final String socialToken = "socialToken";
-        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId");
+        final SignupRequest request = new SignupRequest("name", LocalDate.now(), "molluId", "phoneToken");
         final String memberId = "memberId";
 
 


### PR DESCRIPTION
## 상세 내용
- 매일 자정, 알림을 예약하는 스케쥴러를 구현하였습니다.
- 로컬에서는 스케쥴러가 실행되지 않도록 하였습니다.
- 등록된 알림이 없으면 새로운 알림을 등록 및 예약합니다.
- 서버가 중간에 중단되는 상황에 스케쥴러가 재실행되는 경우, 등록된 알림은 있지만 알림을 다시 예약합니다.
- 예약 시간에 FCM 서버로 요청을 보내, 알림이 허용된 유저들에게 알림이 갑니다.

더 자세한 내용은 개발 일지에 작성하려고 합니다.

추가로, 요청-응답에 대한 소요 시간을 측정하는 로직을 작성하였습니다. 

Close #66 
