### PR TITLE
fix: 그룹원 피드 조회 API를 변경한다.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -26,4 +26,4 @@ chmod +x $JAR_NAME
 
 echo "> $JAR_NAME 실행"
 
-nohup java -jar -Dspring.profiles.active=dev $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &
+nohup java -jar -Duser.timezone=Asia/Seoul -Dspring.profiles.active=dev $JAR_NAME > $REPOSITORY/nohup.out 2>&1 &

--- a/src/main/java/sleepy/mollu/server/content/contentgroup/repository/ContentGroupRepository.java
+++ b/src/main/java/sleepy/mollu/server/content/contentgroup/repository/ContentGroupRepository.java
@@ -1,0 +1,19 @@
+package sleepy.mollu.server.content.contentgroup.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import sleepy.mollu.server.content.contentgroup.domain.ContentGroup;
+import sleepy.mollu.server.group.domain.group.Group;
+
+import java.util.List;
+
+public interface ContentGroupRepository extends JpaRepository<ContentGroup, String> {
+
+    @Query("select cg from ContentGroup cg where cg.group in :groups")
+    Page<ContentGroup> findAllByGroups(List<Group> groups, Pageable pageable);
+
+    @Query("select cg from ContentGroup cg join fetch cg.content where cg in :contentGroups")
+    List<ContentGroup> findAllWithContentByContentGroups(List<ContentGroup> contentGroups);
+}

--- a/src/main/java/sleepy/mollu/server/content/dto/GroupSearchContentResponse.java
+++ b/src/main/java/sleepy/mollu/server/content/dto/GroupSearchContentResponse.java
@@ -2,17 +2,13 @@ package sleepy.mollu.server.content.dto;
 
 import java.time.LocalDateTime;
 
-public record GroupSearchContentResponse(
-        String contentId,
-        String memberUUID,
-        String memberId,
-        String memberName,
-        String location,
-        String groupName,
-        LocalDateTime limitDateTime,
-        LocalDateTime uploadDateTime,
-        String tag,
-        String frontContentSrc,
-        String backContentSrc) {
+public record GroupSearchContentResponse(Member member, Content content) {
 
+    public record Member(String memberId, String molluId, String memberName, String profileSource) {
+    }
+
+    public record Content(String contentId, String location, String groupName, LocalDateTime limitDateTime,
+                          LocalDateTime uploadDateTime, String tag, String frontContentSource,
+                          String backContentSource) {
+    }
 }

--- a/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
@@ -57,23 +57,21 @@ public class ContentServiceImpl implements ContentService {
     private GroupSearchFeedResponse getGroupSearchFeedResponse(Member member, Page<Content> contents) {
 
         return new GroupSearchFeedResponse(contents.stream()
-                .map(content -> {
-                    final String groupName = "groupName";
-                    final LocalDateTime limitDateTime = LocalDateTime.now();
+                .map(content ->
+                        new GroupSearchContentResponse(getMemberResponse(member), getContentResponse(content))
+                ).toList());
+    }
 
-                    return new GroupSearchContentResponse(
-                            content.getId(),
-                            member.getId(),
-                            member.getMolluId(),
-                            member.getName(),
-                            content.getLocation(),
-                            groupName,
-                            limitDateTime,
-                            content.getUpdatedAt(),
-                            content.getContentTag(),
-                            content.getFrontContentSource(),
-                            content.getBackContentSource());
-                }).toList());
+    private GroupSearchContentResponse.Member getMemberResponse(Member member) {
+        return new GroupSearchContentResponse.Member(member.getId(), member.getMolluId(), member.getName(), member.getProfileSource());
+    }
+
+    private GroupSearchContentResponse.Content getContentResponse(Content content) {
+        final String groupName = "groupName";
+        final LocalDateTime limitDateTime = LocalDateTime.now();
+        return new GroupSearchContentResponse.Content(content.getId(), content.getLocation(), groupName, limitDateTime,
+                content.getCreatedAt(), content.getContentTag(),
+                content.getFrontContentSource(), content.getBackContentSource());
     }
 
     // TODO: 로직 수정 및 테스트 코드 작성

--- a/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import sleepy.mollu.server.common.domain.IdConstructor;
 import sleepy.mollu.server.content.contentgroup.domain.ContentGroup;
+import sleepy.mollu.server.content.contentgroup.repository.ContentGroupRepository;
 import sleepy.mollu.server.content.domain.content.Content;
 import sleepy.mollu.server.content.domain.file.ContentFile;
 import sleepy.mollu.server.content.domain.file.ImageContentFile;
@@ -19,6 +20,8 @@ import sleepy.mollu.server.content.exception.ContentNotFoundException;
 import sleepy.mollu.server.content.repository.ContentRepository;
 import sleepy.mollu.server.group.domain.group.Group;
 import sleepy.mollu.server.group.exception.GroupNotFoundException;
+import sleepy.mollu.server.group.groupmember.domain.GroupMember;
+import sleepy.mollu.server.group.groupmember.repository.GroupMemberRepository;
 import sleepy.mollu.server.group.repository.GroupRepository;
 import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
@@ -26,6 +29,7 @@ import sleepy.mollu.server.member.exception.MemberUnAuthorizedException;
 import sleepy.mollu.server.member.repository.MemberRepository;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional
@@ -35,6 +39,8 @@ public class ContentServiceImpl implements ContentService {
     private final MemberRepository memberRepository;
     private final ContentRepository contentRepository;
     private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final ContentGroupRepository contentGroupRepository;
 
     private final IdConstructor idConstructor;
     private final FileHandler fileHandler;
@@ -44,7 +50,8 @@ public class ContentServiceImpl implements ContentService {
     public GroupSearchFeedResponse searchGroupFeed(String memberId, Pageable pageable) {
 
         final Member member = getMember(memberId);
-        final Page<Content> contents = contentRepository.findAll(pageable);
+        final List<Group> groups = getGroups(member);
+        final List<Content> contents = getContents(pageable, groups);
 
         return getGroupSearchFeedResponse(member, contents);
     }
@@ -54,12 +61,28 @@ public class ContentServiceImpl implements ContentService {
                 .orElseThrow(() -> new MemberNotFoundException("[" + memberId + "] 는 존재하지 않는 회원입니다."));
     }
 
-    private GroupSearchFeedResponse getGroupSearchFeedResponse(Member member, Page<Content> contents) {
+    private List<Group> getGroups(Member member) {
+        final List<GroupMember> groupMembers = groupMemberRepository.findAllWithGroupByMember(member);
 
+        return groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .toList();
+    }
+
+    private List<Content> getContents(Pageable pageable, List<Group> groups) {
+        final Page<ContentGroup> contentGroups = contentGroupRepository.findAllByGroups(groups, pageable);
+        final List<ContentGroup> contentGroupsWithContent = contentGroupRepository.findAllWithContentByContentGroups(contentGroups.toList());
+
+        return contentGroupsWithContent.stream()
+                .map(ContentGroup::getContent)
+                .toList();
+    }
+
+    private GroupSearchFeedResponse getGroupSearchFeedResponse(Member member, List<Content> contents) {
         return new GroupSearchFeedResponse(contents.stream()
                 .map(content ->
-                        new GroupSearchContentResponse(getMemberResponse(member), getContentResponse(content))
-                ).toList());
+                        new GroupSearchContentResponse(getMemberResponse(member), getContentResponse(content)))
+                .toList());
     }
 
     private GroupSearchContentResponse.Member getMemberResponse(Member member) {

--- a/src/main/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepository.java
+++ b/src/main/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepository.java
@@ -1,7 +1,14 @@
 package sleepy.mollu.server.group.groupmember.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import sleepy.mollu.server.group.groupmember.domain.GroupMember;
+import sleepy.mollu.server.member.domain.Member;
+
+import java.util.List;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, String> {
+
+    @Query("select gm from GroupMember gm join fetch gm.group g where gm.member = :member")
+    List<GroupMember> findAllWithGroupByMember(Member member);
 }

--- a/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/sleepy/mollu/server/oauth2/controller/OAuth2Controller.java
@@ -54,7 +54,7 @@ public class OAuth2Controller {
     @BadRequestResponse
     @InternalServerErrorResponse
     @GetMapping("/check-id")
-    public ResponseEntity<CheckResponse> signup(@RequestParam String molluId) {
+    public ResponseEntity<CheckResponse> checkId(@RequestParam String molluId) {
 
         return ResponseEntity.ok().body(oauth2Service.checkId(molluId));
     }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -80,6 +80,7 @@
 
     <springProfile name="dev, prod">
         <root level="INFO">
+            <appender-ref ref="STDOUT"/>
             <appender-ref ref="INFO_LOG"/>
             <appender-ref ref="WARN_LOG"/>
             <appender-ref ref="ERROR_LOG"/>


### PR DESCRIPTION
## 상세 내용
- 그룹원 피드 조회 API 응답의 형식을 변경하였습니다.
- 그룹원 피드 조회 서비스의 로직에 그룹을 추가하여 조회하도록 변경하였습니다.


**수정 사항**
_컨텐츠를 생성할 때 제한 시간을 함께 저장해야 합니다._

Close #68 
