### PR TITLE
fix: 컨텐츠 업로드 시 mollu time을 컨텐츠에 함께 저장한다.

### DIFF
--- a/src/main/java/sleepy/mollu/server/content/contentgroup/domain/ContentGroup.java
+++ b/src/main/java/sleepy/mollu/server/content/contentgroup/domain/ContentGroup.java
@@ -25,12 +25,9 @@ public class ContentGroup {
     private Group group;
 
     @Builder
-    public ContentGroup(String id, Group group) {
+    public ContentGroup(String id, Content content, Group group) {
         this.id = id;
-        this.group = group;
-    }
-
-    public void assignContent(Content content) {
         this.content = content;
+        this.group = group;
     }
 }

--- a/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
@@ -5,13 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
-import sleepy.mollu.server.common.domain.FileSource;
-import sleepy.mollu.server.content.contentgroup.domain.ContentGroup;
-import sleepy.mollu.server.content.report.domain.ContentReport;
 import sleepy.mollu.server.member.domain.Member;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -23,54 +17,45 @@ public class Content extends BaseEntity {
     private String id;
 
     @Embedded
+    private Location location;
+
+    @Embedded
     private ContentTag contentTag;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "front_content_source"))
-    private FileSource frontContentSource;
+    private ContentTime contentTime;
 
     @Embedded
-    @AttributeOverride(name = "value", column = @Column(name = "back_content_source"))
-    private FileSource backContentSource;
-
-    @Embedded
-    private Location location;
+    private ContentSource contentSource;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "content")
-    private List<ContentReport> reports = new ArrayList<>();
-
-    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
-    private List<ContentGroup> contentGroups = new ArrayList<>();
-
     @Builder
-    public Content(String id, String contentTag, String frontContentSource, String backContentSource, String location, Member member, ContentGroup contentGroup) {
+    public Content(String id, String location, String contentTag, ContentTime contentTime, ContentSource contentSource, Member member) {
         this.id = id;
-        this.contentTag = new ContentTag(contentTag);
-        this.frontContentSource = new FileSource(frontContentSource);
-        this.backContentSource = new FileSource(backContentSource);
         this.location = new Location(location);
+        this.contentTag = new ContentTag(contentTag);
+        this.contentTime = contentTime;
+        this.contentSource = contentSource;
         this.member = member;
-        addContentGroup(contentGroup);
     }
 
     public String getContentTag() {
         return contentTag.getValue();
     }
 
+    public String getLocation() {
+        return location.getValue();
+    }
+
     public String getFrontContentSource() {
-        return frontContentSource.getValue();
+        return contentSource.getFrontContentSource();
     }
 
     public String getBackContentSource() {
-        return backContentSource.getValue();
-    }
-
-    public String getLocation() {
-        return location.getValue();
+        return contentSource.getBackContentSource();
     }
 
     public boolean isOwner(String memberId) {
@@ -79,14 +64,5 @@ public class Content extends BaseEntity {
 
     public boolean isOwner(Member member) {
         return this.member == member;
-    }
-
-    public void addContentReport(ContentReport contentReport) {
-        this.reports.add(contentReport);
-    }
-
-    private void addContentGroup(ContentGroup contentGroup) {
-        this.contentGroups.add(contentGroup);
-        contentGroup.assignContent(this);
     }
 }

--- a/src/main/java/sleepy/mollu/server/content/domain/content/ContentSource.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/ContentSource.java
@@ -1,0 +1,38 @@
+package sleepy.mollu.server.content.domain.content;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sleepy.mollu.server.common.domain.FileSource;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ContentSource {
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "front_content_source"))
+    private FileSource frontContentSource;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "back_content_source"))
+    private FileSource backContentSource;
+
+    public static ContentSource of(String frontContentSource, String backContentSource) {
+        return new ContentSource(new FileSource(frontContentSource), new FileSource(backContentSource));
+    }
+
+    public String getFrontContentSource() {
+        return frontContentSource.getValue();
+    }
+
+    public String getBackContentSource() {
+        return backContentSource.getValue();
+    }
+}

--- a/src/main/java/sleepy/mollu/server/content/domain/content/ContentTag.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/ContentTag.java
@@ -22,21 +22,10 @@ public class ContentTag {
     }
 
     private void validate(String value) {
-        validateNull(value);
-        validateBlank(value);
-        validateLength(value);
-    }
-
-    private void validateNull(String value) {
         if (value == null) {
-            throw new ContentTagBadRequestException("태그는 null일 수 없습니다.");
+            return;
         }
-    }
-
-    private void validateBlank(String value) {
-        if (value.isBlank()) {
-            throw new ContentTagBadRequestException("태그는 비어있을 수 없습니다.");
-        }
+        validateLength(value);
     }
 
     private void validateLength(String value) {

--- a/src/main/java/sleepy/mollu/server/content/domain/content/ContentTime.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/ContentTime.java
@@ -1,0 +1,23 @@
+package sleepy.mollu.server.content.domain.content;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ContentTime {
+
+    private LocalDateTime molluDateTime;
+    private LocalDateTime uploadDateTime;
+
+    public static ContentTime of(LocalDateTime molluDateTime, LocalDateTime uploadDateTime) {
+        return new ContentTime(molluDateTime, uploadDateTime);
+    }
+}

--- a/src/main/java/sleepy/mollu/server/content/dto/CreateContentRequest.java
+++ b/src/main/java/sleepy/mollu/server/content/dto/CreateContentRequest.java
@@ -3,18 +3,20 @@ package sleepy.mollu.server.content.dto;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
 public record CreateContentRequest(
 
         @NotNull
         String location,
 
-        @NotNull
-        List<String> groupIds,
+        String tag,
 
         @NotNull
-        String tag,
+        LocalDateTime molluDateTime,
+
+        @NotNull
+        LocalDateTime uploadDateTime,
 
         @NotNull
         MultipartFile frontContentFile,

--- a/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
+++ b/src/main/java/sleepy/mollu/server/content/report/domain/ContentReport.java
@@ -22,11 +22,6 @@ public class ContentReport extends Report {
     @Builder
     public ContentReport(String reason, Member member, Content content) {
         super(reason, member);
-        setContent(content);
-    }
-
-    private void setContent(Content content) {
         this.content = content;
-        content.addContentReport(this);
     }
 }

--- a/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
+++ b/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
@@ -18,8 +18,7 @@ class ContentTagTest {
     public static Stream<Arguments> invalidContentTag() {
         return Stream.of(
                 Arguments.of("a".repeat(11)),
-                Arguments.of("박".repeat(11)),
-                Arguments.of(" ")
+                Arguments.of("박".repeat(11))
         );
     }
 
@@ -32,7 +31,6 @@ class ContentTagTest {
 
     @ParameterizedTest
     @MethodSource("invalidContentTag")
-    @NullAndEmptySource
     @DisplayName("태그 객체가 유효하지 않은 값이 생성될 때 예외를 던진다")
     void test1(String value) {
         assertThatThrownBy(() -> new ContentTag(value)).isInstanceOf(ContentTagBadRequestException.class);
@@ -40,6 +38,7 @@ class ContentTagTest {
 
     @ParameterizedTest
     @MethodSource("validContentTag")
+    @NullAndEmptySource
     @DisplayName("태그 객체가 성공적으로 생성된다")
     void test2(String value) {
         assertThatCode(() -> new ContentTag(value)).doesNotThrowAnyException();


### PR DESCRIPTION
## 상세 내용
- 태그는 null을 허용하도록 변경하였습니다.
- 그룹 아이디는 MVP 단계에서는 보내지 않도록 변경하였습니다.
- mollu 타임과, 촬영 시각을 함께 보내도록 변경하였습니다.
- Content의 `@OneToMany` 필드를 삭제하였습니다.

Close #72 
