### PR TITLE
fix: 그룹원 피드 조회 시 그룹명도 함께 조회하도록 변경한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.395'

--- a/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
+++ b/src/main/java/sleepy/mollu/server/common/handler/ControllerAdvice.java
@@ -15,69 +15,79 @@ import sleepy.mollu.server.common.exception.*;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
+//@Slf4j
 public class ControllerAdvice {
 
     private static final String BAD_REQUEST_ERROR_MESSAGE = "잘못된 요청입니다.";
-    private final Logger logger = LoggerFactory.getLogger(this.getClass().getSimpleName());
+    private final Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ExceptionResponse> handleBadRequestException(BadRequestException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(BindException.class)
     public ResponseEntity<ExceptionResponse> handleBindingExceptions(BindException exception) {
+        log.error(exception.getClass().getName());
         final String message = exception.getBindingResult()
                 .getAllErrors()
                 .stream()
                 .map(error -> String.format("%s: %s", ((FieldError) error).getField(), error.getDefaultMessage()))
                 .collect(Collectors.joining(", "));
 
-        logger.warn(message);
+        log.error(message);
 
         return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.badRequest().body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(UnAuthenticatedException.class)
     public ResponseEntity<ExceptionResponse> handleAuthenticationException(UnAuthenticatedException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ExceptionResponse("인증에 실패했습니다."));
     }
 
     @ExceptionHandler(UnAuthorizedException.class)
     public ResponseEntity<ExceptionResponse> handleAuthorizationException(UnAuthorizedException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ExceptionResponse("권한이 없습니다."));
     }
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ExceptionResponse("요청한 리소스를 찾을 수 없습니다."));
     }
 
     @ExceptionHandler(ServletException.class)
     public ResponseEntity<ExceptionResponse> handleServletException(Exception exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponse(BAD_REQUEST_ERROR_MESSAGE));
     }
 
     @ExceptionHandler(ServerException.class)
     public ResponseEntity<ExceptionResponse> handleServerException(ServerException exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ExceptionResponse("처리할 수 없는 예외입니다."));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
-        logger.warn(exception.getMessage());
+        log.error(exception.getClass().getName());
+        log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ExceptionResponse("처리할 수 없는 예외입니다."));
     }
 }

--- a/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/Content.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.BaseEntity;
 import sleepy.mollu.server.member.domain.Member;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -56,6 +58,10 @@ public class Content extends BaseEntity {
 
     public String getBackContentSource() {
         return contentSource.getBackContentSource();
+    }
+
+    public LocalDateTime getMolluDateTime() {
+        return contentTime.getMolluDateTime();
     }
 
     public boolean isOwner(String memberId) {

--- a/src/main/java/sleepy/mollu/server/content/domain/content/ContentTag.java
+++ b/src/main/java/sleepy/mollu/server/content/domain/content/ContentTag.java
@@ -11,21 +11,18 @@ import sleepy.mollu.server.content.exception.ContentTagBadRequestException;
 @NoArgsConstructor
 public class ContentTag {
 
-    public static final int MAX_CONTENT_TAG_LENGTH = 10;
+    private static final int MAX_CONTENT_TAG_LENGTH = 10;
 
     @Column(name = "tag")
     private String value;
 
     public ContentTag(String value) {
-        validate(value);
-        this.value = value;
-    }
-
-    private void validate(String value) {
         if (value == null) {
+            this.value = "";
             return;
         }
         validateLength(value);
+        this.value = value;
     }
 
     private void validateLength(String value) {

--- a/src/main/java/sleepy/mollu/server/content/dto/GroupSearchContentResponse.java
+++ b/src/main/java/sleepy/mollu/server/content/dto/GroupSearchContentResponse.java
@@ -7,7 +7,7 @@ public record GroupSearchContentResponse(Member member, Content content) {
     public record Member(String memberId, String molluId, String memberName, String profileSource) {
     }
 
-    public record Content(String contentId, String location, String groupName, LocalDateTime limitDateTime,
+    public record Content(String contentId, String location, String groupName, LocalDateTime molluDateTime,
                           LocalDateTime uploadDateTime, String tag, String frontContentSource,
                           String backContentSource) {
     }

--- a/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
@@ -30,7 +30,6 @@ import sleepy.mollu.server.member.exception.MemberNotFoundException;
 import sleepy.mollu.server.member.exception.MemberUnAuthorizedException;
 import sleepy.mollu.server.member.repository.MemberRepository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -92,9 +91,8 @@ public class ContentServiceImpl implements ContentService {
     }
 
     private GroupSearchContentResponse.Content getContentResponse(Content content) {
-        final String groupName = "groupName";
-        final LocalDateTime limitDateTime = LocalDateTime.now();
-        return new GroupSearchContentResponse.Content(content.getId(), content.getLocation(), groupName, limitDateTime,
+        final Group group = getGroup();
+        return new GroupSearchContentResponse.Content(content.getId(), content.getLocation(), group.getName(), content.getMolluDateTime(),
                 content.getCreatedAt(), content.getContentTag(),
                 content.getFrontContentSource(), content.getBackContentSource());
     }
@@ -110,6 +108,12 @@ public class ContentServiceImpl implements ContentService {
         saveContentGroup(content);
 
         return content.getId();
+    }
+
+    private String uploadContent(MultipartFile file) {
+        final ContentFile frontContentFile = new ImageContentFile(file);
+
+        return fileHandler.upload(frontContentFile);
     }
 
     private Content saveContent(CreateContentRequest request, String frontContentFileUrl, String backContentFileUrl, Member member) {
@@ -135,12 +139,6 @@ public class ContentServiceImpl implements ContentService {
     private Group getGroup() {
         return groupRepository.findDefaultGroup()
                 .orElseThrow(() -> new GroupNotFoundException("디폴트 그룹이 존재하지 않습니다."));
-    }
-
-    private String uploadContent(MultipartFile file) {
-        final ContentFile frontContentFile = new ImageContentFile(file);
-
-        return fileHandler.upload(frontContentFile);
     }
 
     @Override

--- a/src/main/java/sleepy/mollu/server/group/domain/group/Group.java
+++ b/src/main/java/sleepy/mollu/server/group/domain/group/Group.java
@@ -5,11 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sleepy.mollu.server.common.domain.FileSource;
-import sleepy.mollu.server.group.groupmember.domain.GroupMember;
-import sleepy.mollu.server.member.domain.Member;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "`group`")
@@ -31,9 +26,6 @@ public class Group {
     @AttributeOverride(name = "value", column = @Column(name = "group_profile_source"))
     private FileSource groupProfileSource;
 
-    @OneToMany(mappedBy = "group")
-    private List<GroupMember> groupMembers = new ArrayList<>();
-
     @Builder
     public Group(String id, String name, String introduction, String groupProfileSource) {
         this.id = id;
@@ -42,12 +34,7 @@ public class Group {
         this.groupProfileSource = new FileSource(groupProfileSource);
     }
 
-    public void addGroupMember(GroupMember groupMember) {
-        this.groupMembers.add(groupMember);
-    }
-
-    public boolean hasMember(Member member) {
-        return this.groupMembers.stream()
-                .anyMatch(groupMember -> groupMember.isSameMember(member));
+    public String getName() {
+        return name.getValue();
     }
 }

--- a/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMember.java
+++ b/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMember.java
@@ -30,14 +30,9 @@ public class GroupMember {
     @Builder
     public GroupMember(String id, Group group, Member member, GroupMemberRole role) {
         this.id = id;
-        setGroup(group);
+        this.group = group;
         setMember(member);
         this.role = role;
-    }
-
-    private void setGroup(Group group) {
-        this.group = group;
-        group.addGroupMember(this);
     }
 
     private void setMember(Member member) {

--- a/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMembers.java
+++ b/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMembers.java
@@ -1,0 +1,19 @@
+package sleepy.mollu.server.group.groupmember.domain;
+
+import sleepy.mollu.server.member.domain.Member;
+
+import java.util.Collections;
+import java.util.List;
+
+
+public record GroupMembers(List<GroupMember> groupMembers) {
+
+    public GroupMembers(List<GroupMember> groupMembers) {
+        this.groupMembers = Collections.unmodifiableList(groupMembers);
+    }
+
+    public boolean hasMember(Member member) {
+        return groupMembers.stream()
+                .anyMatch(groupMember -> groupMember.isSameMember(member));
+    }
+}

--- a/src/main/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepository.java
+++ b/src/main/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepository.java
@@ -2,6 +2,8 @@ package sleepy.mollu.server.group.groupmember.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import sleepy.mollu.server.group.domain.group.Group;
 import sleepy.mollu.server.group.groupmember.domain.GroupMember;
 import sleepy.mollu.server.member.domain.Member;
 
@@ -10,5 +12,8 @@ import java.util.List;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, String> {
 
     @Query("select gm from GroupMember gm join fetch gm.group g where gm.member = :member")
-    List<GroupMember> findAllWithGroupByMember(Member member);
+    List<GroupMember> findAllWithGroupByMember(@Param("member") Member member);
+
+    @Query("select gm from GroupMember gm join fetch gm.member m where gm.group = :group")
+    List<GroupMember> findAllWithMemberByGroup(@Param("group") Group group);
 }

--- a/src/main/java/sleepy/mollu/server/group/service/GroupServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/group/service/GroupServiceImpl.java
@@ -8,6 +8,8 @@ import sleepy.mollu.server.group.dto.GroupMemberSearchResponse;
 import sleepy.mollu.server.group.dto.GroupMemberSearchResponse.GroupMemberResponse;
 import sleepy.mollu.server.group.exception.GroupNotFoundException;
 import sleepy.mollu.server.group.groupmember.domain.GroupMember;
+import sleepy.mollu.server.group.groupmember.domain.GroupMembers;
+import sleepy.mollu.server.group.groupmember.repository.GroupMemberRepository;
 import sleepy.mollu.server.group.repository.GroupRepository;
 import sleepy.mollu.server.member.domain.Member;
 import sleepy.mollu.server.member.exception.MemberNotFoundException;
@@ -23,16 +25,15 @@ public class GroupServiceImpl implements GroupService {
 
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
-    // TODO: 2023/07/24 그룹 조회시 fetch join을 하여 N+1 문제 해결하기
     @Override
     public GroupMemberSearchResponse searchGroupMembers(String memberId, String groupId) {
 
         final Member member = getMember(memberId);
         final Group group = getGroup(groupId);
-        validateGroupMember(member, group);
 
-        return getGroupMemberSearchResponse(group);
+        return getGroupMemberSearchResponse(group, member);
     }
 
     private Member getMember(String memberId) {
@@ -45,18 +46,20 @@ public class GroupServiceImpl implements GroupService {
                 .orElseThrow(() -> new GroupNotFoundException("[" + groupId + "]는 존재하지 않는 그룹입니다."));
     }
 
-    private void validateGroupMember(Member member, Group group) {
-        if (!group.hasMember(member)) {
-            throw new MemberUnAuthorizedException("[" + member.getId() + "]는 [" + group.getId() + "]의 그룹원이 아닙니다.");
+    private GroupMemberSearchResponse getGroupMemberSearchResponse(Group group, Member member) {
+        final GroupMembers groupMembers = new GroupMembers(groupMemberRepository.findAllWithMemberByGroup(group));
+        validateGroupMember(groupMembers, member, group.getId());
+        return new GroupMemberSearchResponse(getGroupMembers(groupMembers));
+    }
+
+    private void validateGroupMember(GroupMembers groupMembers, Member member, String groupId) {
+        if (!groupMembers.hasMember(member)) {
+            throw new MemberUnAuthorizedException("[" + member.getId() + "]는 [" + groupId + "] 그룹의 멤버가 아닙니다.");
         }
     }
 
-    private GroupMemberSearchResponse getGroupMemberSearchResponse(Group group) {
-        return new GroupMemberSearchResponse(getGroupMembers(group));
-    }
-
-    private List<GroupMemberResponse> getGroupMembers(Group group) {
-        return group.getGroupMembers().stream()
+    private List<GroupMemberResponse> getGroupMembers(GroupMembers groupMembers) {
+        return groupMembers.groupMembers().stream()
                 .map(GroupMember::getMember)
                 .map(member -> new GroupMemberResponse(member.getId(), member.getName(), member.getProfileSource()))
                 .toList();

--- a/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
+++ b/src/main/java/sleepy/mollu/server/member/repository/MemberRepository.java
@@ -12,6 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     @Query("select case when count(m) > 0 then true else false end from Member m where m.molluId.value = :molluId")
     boolean existsByMolluId(@Param("molluId") String molluId);
 
-    @Query("select m from Member m join Preference p on m.preference = p where p.molluAlarm = true")
+    @Query("select m from Member m join m.preference p where p.molluAlarm = true")
     List<Member> findAllByMolluAlarmAllowed();
 }

--- a/src/main/resources/templates/mollu-alarm.html
+++ b/src/main/resources/templates/mollu-alarm.html
@@ -5,7 +5,7 @@
 </head>
 <body>
 <h1>Send MoLLU Alarm</h1>
-<form th:action="@{/admin/alarm/mollu-alarm}" method="post">
+<form method="post" th:action="@{/admin/alarm/mollu-alarm}">
     <input type="submit" value="MoLLU 알림 전송"/>
 </form>
 </body>

--- a/src/main/resources/templates/mollu-range.html
+++ b/src/main/resources/templates/mollu-range.html
@@ -6,13 +6,13 @@
 <body>
 <h1>MoLLU Time 범위</h1>
 <h2 th:text="${molluRange.from} + ' ~ ' + ${molluRange.to}"></h2>
-<form th:action="@{/admin/alarm/mollu-range}" th:object="${molluRange}" method="post">
+<form method="post" th:action="@{/admin/alarm/mollu-range}" th:object="${molluRange}">
     <label>From:
-        <input type="time" th:value="*{fromString} " name="from"/>
+        <input name="from" th:value="*{fromString} " type="time"/>
     </label>
     <br/>
     <label>To:
-        <input type="time" th:value="*{toString}" name="to"/>
+        <input name="to" th:value="*{toString}" type="time"/>
     </label>
     <input type="submit" value="Update"/>
 </form>

--- a/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
@@ -103,7 +103,7 @@ class ContentControllerTest {
                     .headers(headers));
 
             // then
-            resultActions.andExpect(status().isBadRequest())
+            resultActions.andExpect(status().isCreated())
                     .andDo(print());
         }
 
@@ -118,8 +118,8 @@ class ContentControllerTest {
             final Map<String, String> map = Map.of(
                     "location", "서울 도봉구",
                     "tag", "태그",
-                    "molluDateTime", "2023-07-06 11:45:00",
-                    "uploadDateTime", "2023-07-06 11:45:00"
+                    "molluDateTime", "2023-07-06T11:45:00",
+                    "uploadDateTime", "2023-07-06T11:45:00"
             );
 
             keys.forEach(key -> params.add(key, map.get(key)));

--- a/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
@@ -59,6 +59,36 @@ class ContentControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    @DisplayName("컨텐츠 삭제 API를 호출하면 204를 반환한다")
+    void ContentControllerTest3() throws Exception {
+
+        // given
+        final HttpHeaders headers = getHeaders();
+
+        final String contentId = "contentId";
+
+        // when
+        final ResultActions resultActions = mockMvc.perform(delete("/contents/" + contentId)
+                .headers(headers));
+
+        // then
+        resultActions.andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    private String getAccessToken() {
+        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
+        return jwtToken.accessToken();
+    }
+
+    private HttpHeaders getHeaders() {
+        final String accessToken = getAccessToken();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        return headers;
+    }
+
     @Nested
     @DisplayName("[컨텐츠 업로드 API 호출시] ")
     class ContentUploadTest {
@@ -126,35 +156,5 @@ class ContentControllerTest {
 
             return params;
         }
-    }
-
-    @Test
-    @DisplayName("컨텐츠 삭제 API를 호출하면 204를 반환한다")
-    void ContentControllerTest3() throws Exception {
-
-        // given
-        final HttpHeaders headers = getHeaders();
-
-        final String contentId = "contentId";
-
-        // when
-        final ResultActions resultActions = mockMvc.perform(delete("/contents/" + contentId)
-                .headers(headers));
-
-        // then
-        resultActions.andExpect(status().isNoContent())
-                .andDo(print());
-    }
-
-    private String getAccessToken() {
-        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
-        return jwtToken.accessToken();
-    }
-
-    private HttpHeaders getHeaders() {
-        final String accessToken = getAccessToken();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
-        return headers;
     }
 }

--- a/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
+++ b/src/test/java/sleepy/mollu/server/content/controller/ContentControllerTest.java
@@ -3,6 +3,7 @@ package sleepy.mollu.server.content.controller;
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.jwtmanager.dto.JwtToken;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -17,6 +18,8 @@ import org.springframework.util.MultiValueMap;
 import sleepy.mollu.server.content.service.ContentService;
 import sleepy.mollu.server.oauth2.config.CustomJwtConfig;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -44,10 +47,7 @@ class ContentControllerTest {
         final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("page", "1");
 
-        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
-        final String accessToken = jwtToken.accessToken();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
+        final HttpHeaders headers = getHeaders();
 
         // when
         final ResultActions result = mockMvc.perform(get("/contents/group")
@@ -59,36 +59,73 @@ class ContentControllerTest {
                 .andDo(print());
     }
 
-    @Test
-    @DisplayName("컨텐츠 업로드 API를 호출하면 201을 반환한다.")
-    void ContentControllerTest2() throws Exception {
+    @Nested
+    @DisplayName("[컨텐츠 업로드 API 호출시] ")
+    class ContentUploadTest {
 
-        // given
-        final MockMultipartFile frontContentFile = new MockMultipartFile("frontContentFile", "test_file.png",
-                "image/png", "Spring Framework".getBytes());
-        final MockMultipartFile backContentFile = new MockMultipartFile("backContentFile", "test_file.png",
-                "image/png", "Spring Framework".getBytes());
+        @Test
+        @DisplayName("시간이 비어있으면 400을 반환한다.")
+        void ContentUploadTest3() throws Exception {
+            // given
+            final MockMultipartFile frontContentFile = getMockMultipartFile("frontContentFile");
+            final MockMultipartFile backContentFile = getMockMultipartFile("backContentFile");
 
-        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("location", "서울 도봉구");
-        params.add("groupIds", "1, 2, 3");
-        params.add("tag", "태그");
+            final MultiValueMap<String, String> params = getParams(List.of("location", "tag"));
+            final HttpHeaders headers = getHeaders();
 
-        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
-        final String accessToken = jwtToken.accessToken();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
+            // when
+            final ResultActions resultActions = mockMvc.perform(multipart("/contents")
+                    .file(frontContentFile)
+                    .file(backContentFile)
+                    .params(params)
+                    .headers(headers));
 
-        // when
-        final ResultActions resultActions = mockMvc.perform(multipart("/contents")
-                .file(frontContentFile)
-                .file(backContentFile)
-                .params(params)
-                .headers(headers));
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
 
-        // then
-        resultActions.andExpect(status().isCreated())
-                .andDo(print());
+        @Test
+        @DisplayName("태그를 작성하지 않아도 201을 반환한다.")
+        void ContentUploadTest() throws Exception {
+            // given
+            final MockMultipartFile frontContentFile = getMockMultipartFile("frontContentFile");
+            final MockMultipartFile backContentFile = getMockMultipartFile("backContentFile");
+
+            final MultiValueMap<String, String> params = getParams(List.of("location", "molluDateTime", "uploadDateTime"));
+            final HttpHeaders headers = getHeaders();
+
+            // when
+            final ResultActions resultActions = mockMvc.perform(multipart("/contents")
+                    .file(frontContentFile)
+                    .file(backContentFile)
+                    .params(params)
+                    .headers(headers));
+
+            // then
+            resultActions.andExpect(status().isBadRequest())
+                    .andDo(print());
+        }
+
+        private MockMultipartFile getMockMultipartFile(String contentFile) {
+            return new MockMultipartFile(contentFile, "test_file.png",
+                    "image/png", "Spring Framework".getBytes());
+        }
+
+        private MultiValueMap<String, String> getParams(List<String> keys) {
+            final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+            final Map<String, String> map = Map.of(
+                    "location", "서울 도봉구",
+                    "tag", "태그",
+                    "molluDateTime", "2023-07-06 11:45:00",
+                    "uploadDateTime", "2023-07-06 11:45:00"
+            );
+
+            keys.forEach(key -> params.add(key, map.get(key)));
+
+            return params;
+        }
     }
 
     @Test
@@ -96,10 +133,7 @@ class ContentControllerTest {
     void ContentControllerTest3() throws Exception {
 
         // given
-        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
-        final String accessToken = jwtToken.accessToken();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
+        final HttpHeaders headers = getHeaders();
 
         final String contentId = "contentId";
 
@@ -110,5 +144,17 @@ class ContentControllerTest {
         // then
         resultActions.andExpect(status().isNoContent())
                 .andDo(print());
+    }
+
+    private String getAccessToken() {
+        final JwtToken jwtToken = jwtGenerator.generate("memberId", Set.of("member"));
+        return jwtToken.accessToken();
+    }
+
+    private HttpHeaders getHeaders() {
+        final String accessToken = getAccessToken();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        return headers;
     }
 }

--- a/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
+++ b/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
@@ -1,17 +1,15 @@
 package sleepy.mollu.server.content.domain;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.*;
 import sleepy.mollu.server.content.domain.content.ContentTag;
 import sleepy.mollu.server.content.exception.ContentTagBadRequestException;
 
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 class ContentTagTest {
 
@@ -42,6 +40,16 @@ class ContentTagTest {
     @DisplayName("태그 객체가 성공적으로 생성된다")
     void test2(String value) {
         assertThatCode(() -> new ContentTag(value)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("null 값이 들어올 경우 빈 문자열로 초기화된다")
+    void ContentTagTest() {
+        // given & when
+        final ContentTag contentTag = new ContentTag(null);
+
+        // then
+        assertThat(contentTag.getValue()).isEmpty();
     }
 
 }

--- a/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
+++ b/src/test/java/sleepy/mollu/server/content/domain/ContentTagTest.java
@@ -3,7 +3,9 @@ package sleepy.mollu.server.content.domain;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import sleepy.mollu.server.content.domain.content.ContentTag;
 import sleepy.mollu.server.content.exception.ContentTagBadRequestException;
 

--- a/src/test/java/sleepy/mollu/server/fixture/GroupFixture.java
+++ b/src/test/java/sleepy/mollu/server/fixture/GroupFixture.java
@@ -1,0 +1,29 @@
+package sleepy.mollu.server.fixture;
+
+import sleepy.mollu.server.group.domain.group.Group;
+
+public class GroupFixture {
+
+    public static final String DEFAULT_ID = "group_id";
+    public static final String DEFAULT_NAME = "group_name";
+    public static final String DEFAULT_INTRODUCTION = "introduction";
+    public static final String DEFAULT_GROUP_PROFILE_SOURCE = "group_profile_source";
+
+    public static Group create() {
+        return Group.builder()
+                .id(DEFAULT_ID)
+                .name(DEFAULT_NAME)
+                .introduction(DEFAULT_INTRODUCTION)
+                .groupProfileSource(DEFAULT_GROUP_PROFILE_SOURCE)
+                .build();
+    }
+
+    public static Group create(String id) {
+        return Group.builder()
+                .id(id)
+                .name(DEFAULT_NAME)
+                .introduction(DEFAULT_INTRODUCTION)
+                .groupProfileSource(DEFAULT_GROUP_PROFILE_SOURCE)
+                .build();
+    }
+}

--- a/src/test/java/sleepy/mollu/server/fixture/GroupMemberFixture.java
+++ b/src/test/java/sleepy/mollu/server/fixture/GroupMemberFixture.java
@@ -1,0 +1,40 @@
+package sleepy.mollu.server.fixture;
+
+import sleepy.mollu.server.group.domain.group.Group;
+import sleepy.mollu.server.group.groupmember.domain.GroupMember;
+import sleepy.mollu.server.group.groupmember.domain.GroupMemberRole;
+import sleepy.mollu.server.member.domain.Member;
+
+import java.util.List;
+import java.util.UUID;
+
+public class GroupMemberFixture {
+
+    public static final String DEFAULT_ID = "id";
+    public static final GroupMemberRole DEFAULT_ROLE = GroupMemberRole.MEMBER;
+
+    public static GroupMember create(Group group, Member member) {
+        return GroupMember.builder()
+                .id(DEFAULT_ID)
+                .role(DEFAULT_ROLE)
+                .group(group)
+                .member(member)
+                .build();
+    }
+
+    public static GroupMember create(String id, Group group, Member member) {
+        return GroupMember.builder()
+                .id(id)
+                .role(DEFAULT_ROLE)
+                .group(group)
+                .member(member)
+                .build();
+    }
+
+    public static List<GroupMember> createAll(List<Group> groups, List<Member> members) {
+        return groups.stream()
+                .flatMap(group -> members.stream()
+                        .map(member -> create(UUID.randomUUID().toString(), group, member)))
+                .toList();
+    }
+}

--- a/src/test/java/sleepy/mollu/server/fixture/MemberFixture.java
+++ b/src/test/java/sleepy/mollu/server/fixture/MemberFixture.java
@@ -1,0 +1,33 @@
+package sleepy.mollu.server.fixture;
+
+import sleepy.mollu.server.member.domain.Member;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public class MemberFixture {
+
+    public static final String DEFAULT_ID = "memberId";
+    public static final String DEFAULT_NAME = "name";
+    public static final LocalDate DEFAULT_BIRTHDAY = LocalDate.now();
+
+    public static Member create() {
+        return Member.builder()
+                .id(DEFAULT_ID)
+                .molluId(UUID.randomUUID().toString().substring(0, 20))
+                .name(DEFAULT_NAME)
+                .birthday(DEFAULT_BIRTHDAY)
+                .preference(PreferenceFixture.create())
+                .build();
+    }
+
+    public static Member create(String id, String molluId) {
+        return Member.builder()
+                .id(id)
+                .molluId(molluId)
+                .name(DEFAULT_NAME)
+                .birthday(DEFAULT_BIRTHDAY)
+                .preference(PreferenceFixture.create())
+                .build();
+    }
+}

--- a/src/test/java/sleepy/mollu/server/fixture/PreferenceFixture.java
+++ b/src/test/java/sleepy/mollu/server/fixture/PreferenceFixture.java
@@ -1,0 +1,13 @@
+package sleepy.mollu.server.fixture;
+
+import sleepy.mollu.server.member.domain.Preference;
+
+public class PreferenceFixture {
+
+    public static Preference create() {
+        return Preference.builder()
+                .molluAlarm(true)
+                .contentAlarm(true)
+                .build();
+    }
+}

--- a/src/test/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/group/groupmember/repository/GroupMemberRepositoryTest.java
@@ -1,0 +1,96 @@
+package sleepy.mollu.server.group.groupmember.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import sleepy.mollu.server.fixture.GroupFixture;
+import sleepy.mollu.server.fixture.GroupMemberFixture;
+import sleepy.mollu.server.fixture.MemberFixture;
+import sleepy.mollu.server.group.domain.group.Group;
+import sleepy.mollu.server.group.groupmember.domain.GroupMember;
+import sleepy.mollu.server.group.repository.GroupRepository;
+import sleepy.mollu.server.member.domain.Member;
+import sleepy.mollu.server.member.repository.MemberRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class GroupMemberRepositoryTest {
+
+    @Autowired
+    private GroupMemberRepository groupMemberRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private Member member1, member2;
+    private Group group1, group2;
+
+    @BeforeEach
+    void setUp() {
+        member1 = MemberFixture.create("member1", "molluId1");
+        member2 = MemberFixture.create("member2", "molluId2");
+        final List<Member> members = List.of(member1, member2);
+
+        group1 = GroupFixture.create("group1");
+        group2 = GroupFixture.create("group2");
+        final List<Group> groups = List.of(group1, group2);
+
+        memberRepository.saveAll(members);
+        groupRepository.saveAll(groups);
+        groupMemberRepository.saveAll(GroupMemberFixture.createAll(groups, members));
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("[findAllWithGroupByMember 호출시] 멤버가 속한 그룹멤버 목록을 그룹과 함께 조회한다.")
+    void GroupMemberRepositoryTest() {
+        // given & when
+        System.out.println("---------");
+        final List<GroupMember> groupMembers = groupMemberRepository.findAllWithGroupByMember(member1);
+        System.out.println("---------");
+
+        System.out.println("---------");
+        final List<String> groupNames = groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .map(Group::getName)
+                .toList();
+        System.out.println("---------");
+
+        // then
+        assertThat(groupNames).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("[findAllWithMemberByGroup 호출시] 그룹이 속한 그룹멤버 목록을 멤버와 함께 조회한다.")
+    void GroupMemberRepositoryTest2() {
+        // given & when
+        System.out.println("---------");
+        final List<GroupMember> groupMembers = groupMemberRepository.findAllWithMemberByGroup(group1);
+        System.out.println("---------");
+
+        System.out.println("---------");
+        final List<String> memberNames = groupMembers.stream()
+                .map(GroupMember::getMember)
+                .map(Member::getName)
+                .toList();
+        System.out.println("---------");
+
+        // then
+        assertThat(memberNames).hasSize(2);
+    }
+
+}

--- a/src/test/java/sleepy/mollu/server/group/service/GroupServiceTest.java
+++ b/src/test/java/sleepy/mollu/server/group/service/GroupServiceTest.java
@@ -102,7 +102,8 @@ class GroupServiceTest {
             given(groupRepository.findById(groupId)).willReturn(Optional.of(group));
             given(groupMemberRepository.findAllWithMemberByGroup(group)).willReturn(List.of(groupMember));
             given(groupMember.isSameMember(member)).willReturn(true);
-            given(groupMember.getMember()).willReturn(member);;
+            given(groupMember.getMember()).willReturn(member);
+            ;
 
             // when
             final GroupMemberSearchResponse response = groupService.searchGroupMembers(memberId, groupId);


### PR DESCRIPTION
## 상세 내용
- ControllerAdvice의 예외 처리 방식을 변경하였습니다.
- 컨텐츠 업로드 컨트롤러의 테스트를 작성하였습니다.
- Group <-> GroupMember의 일대다 관계를 삭제하였고 fetch join을 도입하였습니다.
- 그룹원 피드 조회 API의 응답 포맷을 변경하였습니다.

Close #73 
