### PR TITLE
fix: 로그인과 피드 조회 변경

### DIFF
--- a/src/main/java/sleepy/mollu/server/content/contentgroup/repository/ContentGroupRepositoryImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/contentgroup/repository/ContentGroupRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ContentGroupRepositoryImpl implements CustomContentGroupRepository 
                 .join(contentGroup.content, content).fetchJoin()
                 .join(content.member).fetchJoin()
                 .where(contentGroup.group.in(groups), cursorIdAndCursorEndDate(cursorId, cursorEndDate))
-                .orderBy(contentGroup.createdAt.desc())
+                .orderBy(contentGroup.createdAt.desc(), contentGroup.id.asc())
                 .limit(pageSize)
                 .fetch();
     }
@@ -37,6 +37,6 @@ public class ContentGroupRepositoryImpl implements CustomContentGroupRepository 
 
         return contentGroup.createdAt.lt(cursorEndDate)
                 .or(contentGroup.createdAt.eq(cursorEndDate)
-                        .and(contentGroup.id.ne(cursorId)));
+                        .and(contentGroup.id.gt(cursorId)));
     }
 }

--- a/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
+++ b/src/main/java/sleepy/mollu/server/content/service/ContentServiceImpl.java
@@ -54,9 +54,7 @@ public class ContentServiceImpl implements ContentService {
         final Member member = getMember(memberId);
         final List<Group> groups = getGroups(member);
         final List<ContentGroup> contentGroups = getContentGroups(groups, cursorId, cursorEndDate);
-        final List<Content> contents = contentGroups.stream()
-                .map(ContentGroup::getContent)
-                .toList();
+        final List<Content> contents = getContents(contentGroups);
         final Cursor cursor = getCursor(contentGroups);
 
         return getGroupSearchFeedResponse(cursor, contents);
@@ -79,7 +77,17 @@ public class ContentServiceImpl implements ContentService {
         return contentGroupRepository.findGroupFeed(groups, PAGE_SIZE, cursorId, cursorEndDate);
     }
 
+    private List<Content> getContents(List<ContentGroup> contentGroups) {
+        return contentGroups.stream()
+                .map(ContentGroup::getContent)
+                .toList();
+    }
+
     private Cursor getCursor(List<ContentGroup> contentGroups) {
+        if (contentGroups.isEmpty()) {
+            return new Cursor(null, null);
+        }
+
         final ContentGroup lastContentGroup = contentGroups.get(contentGroups.size() - 1);
 
         return new Cursor(lastContentGroup.getId(), lastContentGroup.getCreatedAt());

--- a/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMember.java
+++ b/src/main/java/sleepy/mollu/server/group/groupmember/domain/GroupMember.java
@@ -13,7 +13,7 @@ import sleepy.mollu.server.member.domain.Member;
 public class GroupMember {
 
     @Id
-    @Column(name = "relation_id")
+    @Column(name = "group_member_id")
     private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/test/java/sleepy/mollu/server/RepositoryTest.java
+++ b/src/test/java/sleepy/mollu/server/RepositoryTest.java
@@ -61,7 +61,7 @@ public class RepositoryTest {
         contentGroupRepository.save(ContentGroupFixture.create(content, group));
     }
 
-    protected void saveContentGroups(List<Content> contents, List<Group> groups) {
-        contentGroupRepository.saveAll(ContentGroupFixture.createAll(contents, groups));
+    protected List<ContentGroup> saveContentGroups(List<Content> contents, List<Group> groups) {
+        return contentGroupRepository.saveAll(ContentGroupFixture.createAll(contents, groups));
     }
 }

--- a/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceTest.java
+++ b/src/test/java/sleepy/mollu/server/oauth2/service/OAuth2ServiceTest.java
@@ -67,6 +67,7 @@ class OAuth2ServiceTest {
         private final String memberId = "memberId";
         private final String type = "type";
         private final String socialToken = "socialToken";
+        private final Member member = mock(Member.class);
 
         @Test
         @DisplayName("회원가입을 하지 않았으면 예외를 발생시킨다.")
@@ -76,7 +77,7 @@ class OAuth2ServiceTest {
             given(oAuth2ClientMap.get(anyString())).willReturn(oAuth2Client);
 
             given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
-            given(memberRepository.existsById(memberId)).willReturn(false);
+            given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> oAuth2Service.login(type, socialToken))
@@ -94,7 +95,7 @@ class OAuth2ServiceTest {
             final String refreshToken = "refreshToken";
 
             given(oAuth2Client.getMemberId(anyString())).willReturn(memberId);
-            given(memberRepository.existsById(memberId)).willReturn(true);
+            given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
             given(jwtGenerator.generate(anyString())).willReturn(JwtToken.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)


### PR DESCRIPTION
## 상세 내용
- 로그인시 리프레시 토큰을 업데이트하도록 변경하였습니다.
- 피드 조회 시 생성일자가 같으면 ID를 기준으로 오름차순 정렬하도록 변경하여 중복 피드를 조회하지 않도록 하였습니다.
- 조회된 피드가 없으면 cursor가 null을 응답하도록 변경하였습니다.
